### PR TITLE
Sanitize email connection logging

### DIFF
--- a/soft-sme-backend/src/services/emailService.ts
+++ b/soft-sme-backend/src/services/emailService.ts
@@ -675,8 +675,17 @@ This quote is valid until ${data.validUntil}.
     try {
       const userSettings = await this.getUserEmailSettings(userId);
       console.log('Testing email connection for user:', userId);
-      console.log('User email settings:', userSettings);
-      
+      if (userSettings) {
+        const { email_host: host, email_user: username } = userSettings;
+        console.log('User email settings (sanitized):', {
+          userId,
+          host,
+          username
+        });
+      } else {
+        console.log('No active email settings found for user:', userId);
+      }
+
       const { transporter, fromEmail } = await this.getTransporterForUser(userId);
       console.log('From email address:', fromEmail);
       


### PR DESCRIPTION
## Summary
- sanitize the email connection test log output to avoid printing raw user credentials
- log only safe identifying information when inspecting user email settings prior to verification

## Testing
- npm run dev *(fails: database host unreachable in container)*
- npx ts-node tmp-test-email.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3186dd1788324aea5526ea35cc30a