### PR TITLE
Add customer general notes support

### DIFF
--- a/soft-sme-frontend/src/components/UnifiedCustomerDialog.tsx
+++ b/soft-sme-frontend/src/components/UnifiedCustomerDialog.tsx
@@ -28,6 +28,7 @@ export interface CustomerFormValues {
   country: string;
   postal_code: string;
   website: string;
+  general_notes: string;
 }
 
 interface UnifiedCustomerDialogProps {
@@ -52,6 +53,7 @@ const defaultCustomer: CustomerFormValues = {
   country: '',
   postal_code: '',
   website: '',
+  general_notes: '',
 };
 
 const UnifiedCustomerDialog: React.FC<UnifiedCustomerDialogProps> = ({
@@ -340,6 +342,17 @@ const UnifiedCustomerDialog: React.FC<UnifiedCustomerDialogProps> = ({
           </Grid>
           <Grid item xs={12}>
             <TextField name="website" label="Website" value={customer.website} onChange={handleInputChange} fullWidth />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              name="general_notes"
+              label="General Notes"
+              value={customer.general_notes}
+              onChange={handleInputChange}
+              fullWidth
+              multiline
+              minRows={4}
+            />
           </Grid>
 
           {isEditMode && customerId && (

--- a/soft-sme-frontend/src/pages/CustomerDetailPage.tsx
+++ b/soft-sme-frontend/src/pages/CustomerDetailPage.tsx
@@ -41,7 +41,8 @@ const CustomerDetailPage: React.FC = () => {
     country: '',
     postal_code: '',
     contact_person: '',
-    website: ''
+    website: '',
+    general_notes: ''
   });
 
   useEffect(() => {

--- a/soft-sme-frontend/src/pages/CustomerListPage.tsx
+++ b/soft-sme-frontend/src/pages/CustomerListPage.tsx
@@ -158,6 +158,7 @@ const CustomerListPage: React.FC = () => {
               postal_code: '',
               contact_person: '',
               website: '',
+              general_notes: '',
               created_at: '',
               updated_at: ''
             });

--- a/soft-sme-frontend/src/types/customer.ts
+++ b/soft-sme-frontend/src/types/customer.ts
@@ -14,6 +14,7 @@ export interface Customer {
   postal_code?: string;
   contact_person?: string;
   website?: string;
+  general_notes?: string;
   created_at: string;
   updated_at: string;
-} 
+}


### PR DESCRIPTION
## Summary
- add general notes persistence support to customer API endpoints
- surface a general notes field throughout customer dialogs and supporting types

## Testing
- npm run lint *(fails: ESLint configuration is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e322c223608324acecc0b6c9589980