### PR TITLE
Separate quote and sales order numbering sequences

### DIFF
--- a/soft-sme-backend/src/routes/salesOrderRoutes.ts
+++ b/soft-sme-backend/src/routes/salesOrderRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { pool } from '../db';
-import { getNextSequenceNumberForYear } from '../utils/sequence';
+import { getNextSalesOrderSequenceNumberForYear } from '../utils/sequence';
 import PDFDocument from 'pdfkit';
 import fs from 'fs';
 import path from 'path';
@@ -328,14 +328,15 @@ router.post('/', async (req: Request, res: Response) => {
     const idRes = await client.query("SELECT nextval('salesorderhistory_sales_order_id_seq')");
     const newSalesOrderId = idRes.rows[0].nextval;
     const currentYear = new Date().getFullYear();
-    const { sequenceNumber, nnnnn } = await getNextSequenceNumberForYear(currentYear);
+    const { sequenceNumber, nnnnn } = await getNextSalesOrderSequenceNumberForYear(currentYear);
     const formattedSONumber = `SO-${currentYear}-${nnnnn.toString().padStart(5, '0')}`;
     const salesOrderQuery = `
-      INSERT INTO salesorderhistory (sales_order_id, sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);
+      INSERT INTO salesorderhistory (sales_order_id, sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number, quote_id, source_quote_number)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17);
     `;
     const customerIdInt = customer_id !== undefined && customer_id !== null ? parseInt(customer_id, 10) : null;
     const quoteIdInt = req.body.quote_id !== undefined && req.body.quote_id !== null ? parseInt(req.body.quote_id, 10) : null;
+    const sourceQuoteNumber = req.body.source_quote_number || null;
     const estimatedCostNum = estimated_cost !== undefined && estimated_cost !== null ? parseFloat(estimated_cost) : 0;
     const lineItemsParsed = (trimmedLineItems || []).map((item: any) => ({
       ...item,
@@ -359,6 +360,8 @@ router.post('/', async (req: Request, res: Response) => {
       status || 'Open',
       estimatedCostNum,
       sequenceNumber,
+      quoteIdInt,
+      sourceQuoteNumber,
     ];
     await client.query(salesOrderQuery, salesOrderValues);
     // For each line item, upsert all fields
@@ -495,20 +498,28 @@ if (lineItems && lineItems.length > 0) {
     'estimated_cost',
     'sequence_number',
     'customer_po_number',
-    'vin_number'
+    'vin_number',
+    'subtotal',
+    'total_gst_amount',
+    'total_amount',
+    'quote_id',
+    'source_quote_number'
   ];
     // Update sales order header fields if provided
     if (Object.keys(salesOrderData).length > 0) {
-      const updateFields = [];
-      const updateValues = [];
+      const updateFields: string[] = [];
+      const updateValues: any[] = [];
       let paramCount = 1;
       for (const [key, value] of Object.entries(salesOrderData)) {
         if (allowedFields.includes(key) && value !== undefined && value !== null) {
-          let coercedValue = value;
+          let coercedValue: any = value;
           if (key === 'subtotal') coercedValue = parseFloat(salesOrderData.subtotal);
           if (key === 'total_gst_amount') coercedValue = parseFloat(salesOrderData.total_gst_amount);
           if (key === 'total_amount') coercedValue = parseFloat(salesOrderData.total_amount);
           if (key === 'estimated_cost') coercedValue = parseFloat(salesOrderData.estimated_cost);
+          if (key === 'quote_id') {
+            coercedValue = value === null ? null : parseInt(value as any, 10);
+          }
           updateFields.push(`${key} = $${paramCount}`);
           updateValues.push(coercedValue);
           paramCount++;

--- a/soft-sme-backend/src/utils/sequence.ts
+++ b/soft-sme-backend/src/utils/sequence.ts
@@ -1,24 +1,37 @@
 import { pool } from '../db';
 
-export async function getNextSequenceNumberForYear(year: number): Promise<{ sequenceNumber: string, nnnnn: number }> {
+type SequenceSource = 'quotes' | 'salesorderhistory';
+
+async function getNextSequenceNumberForTable(
+  table: SequenceSource,
+  year: number
+): Promise<{ sequenceNumber: string; nnnnn: number }> {
   const yearPrefix = `${year}`;
-  // Get max from both tables
-  const result = await pool.query(
-    `
-    SELECT MAX(seq) as max_seq FROM (
-      SELECT CAST(SUBSTRING(CAST(sequence_number AS TEXT), 5, 5) AS INTEGER) as seq
-      FROM quotes WHERE sequence_number IS NOT NULL AND CAST(sequence_number AS TEXT) LIKE $1
-      UNION ALL
-      SELECT CAST(SUBSTRING(CAST(sequence_number AS TEXT), 5, 5) AS INTEGER) as seq
-      FROM salesorderhistory WHERE sequence_number IS NOT NULL AND CAST(sequence_number AS TEXT) LIKE $1
-    ) AS all_seqs
-    `,
-    [`${yearPrefix}%`]
-  );
-  const maxSeq = result.rows[0].max_seq || 0;
+  const likeValue = `${yearPrefix}%`;
+
+  const query = table === 'quotes'
+    ? `SELECT MAX(CAST(SUBSTRING(CAST(sequence_number AS TEXT), 5, 5) AS INTEGER)) AS max_seq
+       FROM quotes
+       WHERE sequence_number IS NOT NULL
+         AND CAST(sequence_number AS TEXT) LIKE $1`
+    : `SELECT MAX(CAST(SUBSTRING(CAST(sequence_number AS TEXT), 5, 5) AS INTEGER)) AS max_seq
+       FROM salesorderhistory
+       WHERE sequence_number IS NOT NULL
+         AND CAST(sequence_number AS TEXT) LIKE $1`;
+
+  const result = await pool.query(query, [likeValue]);
+  const maxSeq = result.rows[0]?.max_seq || 0;
   const nextSeq = maxSeq + 1;
   const sequenceNumber = `${yearPrefix}${nextSeq.toString().padStart(5, '0')}`;
   return { sequenceNumber, nnnnn: nextSeq };
+}
+
+export function getNextQuoteSequenceNumberForYear(year: number) {
+  return getNextSequenceNumberForTable('quotes', year);
+}
+
+export function getNextSalesOrderSequenceNumberForYear(year: number) {
+  return getNextSequenceNumberForTable('salesorderhistory', year);
 }
 
 export async function getNextPurchaseOrderNumberForYear(year: number): Promise<{ poNumber: string, nnnnn: number }> {


### PR DESCRIPTION
## Summary
- split the shared sequence helper into dedicated quote and sales order generators and switch the quote APIs to the new helpers
- generate fresh sales order numbers when converting from a quote while persisting the originating quote number, and allow sales order creates/updates to carry quote references
- update the agent tooling to respect the independent sales order sequence and propagate quote reference fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3260b34dc8324b45ae09e4a8a2977