### PR TITLE
fix: ensure invoice status toggles show needed and done

### DIFF
--- a/soft-sme-backend/src/routes/quoteRoutes.ts
+++ b/soft-sme-backend/src/routes/quoteRoutes.ts
@@ -216,11 +216,11 @@ router.post('/:id/convert-to-sales-order', async (req: Request, res: Response) =
     const salesOrderResult = await client.query(
       `INSERT INTO salesorderhistory (
         sales_order_number, customer_id, sales_date, product_name, product_description,
-        estimated_cost, status, quote_id, subtotal, total_gst_amount, total_amount, sequence_number, terms, customer_po_number, vin_number, source_quote_number
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING *`,
+        estimated_cost, status, quote_id, subtotal, total_gst_amount, total_amount, sequence_number, terms, customer_po_number, vin_number, vehicle_make, vehicle_model, invoice_status, source_quote_number
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) RETURNING *`,
       [formattedSONumber, quote.customer_id, conversionDate.toISOString().split('T')[0],
        quote.product_name, quote.product_description, quote.estimated_cost, 'Open', quote.quote_id,
-       0, 0, 0, soSequenceNumber, quote.terms || null, quote.customer_po_number || null, quote.vin_number || null, quote.quote_number || null]
+       0, 0, 0, soSequenceNumber, quote.terms || null, quote.customer_po_number || null, quote.vin_number || null, null, null, null, quote.quote_number || null]
     );
 
     const salesOrderId = salesOrderResult.rows[0].sales_order_id;

--- a/soft-sme-backend/src/routes/salesOrderRoutes.ts
+++ b/soft-sme-backend/src/routes/salesOrderRoutes.ts
@@ -138,6 +138,36 @@ async function createQBOCustomer(customerData: any, accessToken: string, realmId
   }
 }
 
+const parseBoolean = (value: any): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) return false;
+  }
+  return Boolean(value);
+};
+
+const normalizeInvoiceStatus = (value: any): 'needed' | 'done' | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return null;
+    if (['needed', 'need', 'required', 'pending'].includes(normalized)) return 'needed';
+    if (['done', 'complete', 'completed', 'sent'].includes(normalized)) return 'done';
+    if (['true', 't', 'yes', 'y', '1', 'on'].includes(normalized)) return 'needed';
+    if (['false', 'f', 'no', 'n', '0', 'off'].includes(normalized)) return null;
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'needed' : null;
+  }
+  if (typeof value === 'number') {
+    return value > 0 ? 'needed' : null;
+  }
+  return null;
+};
+
 // Helper function to recalculate aggregated parts to order
 async function recalculateAggregatedPartsToOrder() {
   try {
@@ -286,7 +316,7 @@ router.post('/:id/recalculate', async (req: Request, res: Response) => {
 
 // Create a new sales order
 router.post('/', async (req: Request, res: Response) => {
-  const { customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, status, estimated_cost, lineItems, user_id } = req.body;
+  const { customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, vehicle_make, vehicle_model, invoice_status, invoice_required, status, estimated_cost, lineItems, user_id } = req.body;
 
   // Trim string fields
   const trimmedProductName = product_name ? product_name.trim() : '';
@@ -294,6 +324,9 @@ router.post('/', async (req: Request, res: Response) => {
   const trimmedTerms = terms ? terms.trim() : '';
   const trimmedCustomerPoNumber = customer_po_number ? customer_po_number.trim() : '';
   const trimmedVinNumber = vin_number ? vin_number.trim() : '';
+  const trimmedVehicleMake = vehicle_make ? vehicle_make.trim() : '';
+  const trimmedVehicleModel = vehicle_model ? vehicle_model.trim() : '';
+  const normalizedInvoiceStatus = normalizeInvoiceStatus(invoice_status ?? invoice_required);
   const trimmedLineItems = lineItems.map((item: any) => ({
     ...item,
     part_number: item.part_number ? item.part_number.trim() : '',
@@ -331,8 +364,8 @@ router.post('/', async (req: Request, res: Response) => {
     const { sequenceNumber, nnnnn } = await getNextSalesOrderSequenceNumberForYear(currentYear);
     const formattedSONumber = `SO-${currentYear}-${nnnnn.toString().padStart(5, '0')}`;
     const salesOrderQuery = `
-      INSERT INTO salesorderhistory (sales_order_id, sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number, quote_id, source_quote_number)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17);
+      INSERT INTO salesorderhistory (sales_order_id, sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, vehicle_make, vehicle_model, invoice_status, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number, quote_id, source_quote_number)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20);
     `;
     const customerIdInt = customer_id !== undefined && customer_id !== null ? parseInt(customer_id, 10) : null;
     const quoteIdInt = req.body.quote_id !== undefined && req.body.quote_id !== null ? parseInt(req.body.quote_id, 10) : null;
@@ -354,6 +387,9 @@ router.post('/', async (req: Request, res: Response) => {
       trimmedTerms,
       trimmedCustomerPoNumber,
       trimmedVinNumber,
+      trimmedVehicleMake,
+      trimmedVehicleModel,
+      normalizedInvoiceStatus,
       0, // subtotal - will be calculated by backend
       0, // total_gst_amount - will be calculated by backend
       0, // total_amount - will be calculated by backend
@@ -454,6 +490,15 @@ router.put('/:id', async (req: Request, res: Response) => {
   if (salesOrderData.terms) salesOrderData.terms = salesOrderData.terms.trim();
   if (salesOrderData.customer_po_number) salesOrderData.customer_po_number = salesOrderData.customer_po_number.trim();
   if (salesOrderData.vin_number) salesOrderData.vin_number = salesOrderData.vin_number.trim();
+  if (salesOrderData.vehicle_make) salesOrderData.vehicle_make = salesOrderData.vehicle_make.trim();
+  if (salesOrderData.vehicle_model) salesOrderData.vehicle_model = salesOrderData.vehicle_model.trim();
+  if (Object.prototype.hasOwnProperty.call(salesOrderData, 'invoice_required')) {
+    salesOrderData.invoice_status = normalizeInvoiceStatus((salesOrderData as any).invoice_required);
+    delete (salesOrderData as any).invoice_required;
+  }
+  if (Object.prototype.hasOwnProperty.call(salesOrderData, 'invoice_status')) {
+    salesOrderData.invoice_status = normalizeInvoiceStatus(salesOrderData.invoice_status);
+  }
 
   // Trim string fields in lineItems
   const trimmedLineItems = lineItems ? lineItems.map((item: any) => ({
@@ -499,6 +544,9 @@ if (lineItems && lineItems.length > 0) {
     'sequence_number',
     'customer_po_number',
     'vin_number',
+    'vehicle_make',
+    'vehicle_model',
+    'invoice_status',
     'subtotal',
     'total_gst_amount',
     'total_amount',
@@ -511,12 +559,13 @@ if (lineItems && lineItems.length > 0) {
       const updateValues: any[] = [];
       let paramCount = 1;
       for (const [key, value] of Object.entries(salesOrderData)) {
-        if (allowedFields.includes(key) && value !== undefined && value !== null) {
+        if (allowedFields.includes(key) && value !== undefined && (value !== null || key === 'invoice_status')) {
           let coercedValue: any = value;
           if (key === 'subtotal') coercedValue = parseFloat(salesOrderData.subtotal);
           if (key === 'total_gst_amount') coercedValue = parseFloat(salesOrderData.total_gst_amount);
           if (key === 'total_amount') coercedValue = parseFloat(salesOrderData.total_amount);
           if (key === 'estimated_cost') coercedValue = parseFloat(salesOrderData.estimated_cost);
+          if (key === 'invoice_status') coercedValue = normalizeInvoiceStatus(value);
           if (key === 'quote_id') {
             coercedValue = value === null ? null : parseInt(value as any, 10);
           }
@@ -734,12 +783,24 @@ router.get('/:id/pdf', async (req: Request, res: Response) => {
       450, y
     );
     y += 16;
-    // Third line: VIN # (conditional rendering)
-    if (salesOrder.vin_number && salesOrder.vin_number.trim() !== '') {
-      doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('VIN #:', 50, y);
-      doc.font('Helvetica').fontSize(11).fillColor('#000000').text(salesOrder.vin_number, 170, y);
-      y += 16;
-    }
+    const vinValue = salesOrder.vin_number?.trim() || '';
+    doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('VIN #:', 50, y);
+    doc.font('Helvetica').fontSize(11).fillColor('#000000').text(vinValue || 'N/A', 170, y);
+    doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Invoice:', 320, y);
+    const invoiceLabel = salesOrder.invoice_status === 'done'
+      ? 'Done'
+      : salesOrder.invoice_status === 'needed'
+        ? 'Needed'
+        : '—';
+    doc.font('Helvetica').fontSize(11).fillColor('#000000').text(invoiceLabel, 450, y);
+    y += 16;
+    const makeValue = salesOrder.vehicle_make?.trim() || '';
+    const modelValue = salesOrder.vehicle_model?.trim() || '';
+    doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Make:', 50, y);
+    doc.font('Helvetica').fontSize(11).fillColor('#000000').text(makeValue || 'N/A', 170, y);
+    doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Model:', 320, y);
+    doc.font('Helvetica').fontSize(11).fillColor('#000000').text(modelValue || 'N/A', 450, y);
+    y += 16;
     y += 8;
     // Product Description below
     doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Product Description:', 50, y);

--- a/soft-sme-backend/src/services/agentV2/tools.ts
+++ b/soft-sme-backend/src/services/agentV2/tools.ts
@@ -13,6 +13,32 @@ export class AgentToolsV2 {
     this.pdfService = new PDFService(pool);
   }
 
+  private toBoolean(value: any): boolean {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true;
+      if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) return false;
+    }
+    return Boolean(value);
+  }
+
+  private normalizeInvoiceStatus(value: any): 'needed' | 'done' | null {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (!normalized) return null;
+      if (['needed', 'need', 'required', 'pending'].includes(normalized)) return 'needed';
+      if (['done', 'complete', 'completed', 'sent'].includes(normalized)) return 'done';
+      if (['true', 't', 'yes', 'y', '1', 'on'].includes(normalized)) return 'needed';
+      if (['false', 'f', 'no', 'n', '0', 'off'].includes(normalized)) return null;
+    }
+    if (typeof value === 'boolean') return value ? 'needed' : null;
+    if (typeof value === 'number') return value > 0 ? 'needed' : null;
+    return null;
+  }
+
   // Utility to audit tool execution
   private async audit(sessionId: number, tool: string, input: any, output: any, success = true) {
     await this.pool.query(
@@ -52,9 +78,10 @@ export class AgentToolsV2 {
       const subtotal = Number(header.subtotal || 0);
       const gst = Number(header.total_gst_amount || subtotal * 0.05);
       const total = Number(header.total_amount || subtotal + gst);
+      const invoiceStatus = this.normalizeInvoiceStatus(header.invoice_status ?? header.invoice_required);
       const insert = await client.query(
-        `INSERT INTO salesorderhistory (sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number, quote_id, source_quote_number)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING sales_order_id`,
+        `INSERT INTO salesorderhistory (sales_order_number, customer_id, sales_date, product_name, product_description, terms, customer_po_number, vin_number, vehicle_make, vehicle_model, invoice_status, subtotal, total_gst_amount, total_amount, status, estimated_cost, sequence_number, quote_id, source_quote_number)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18) RETURNING sales_order_id`,
         [
           soNum,
           header.customer_id || null,
@@ -64,6 +91,9 @@ export class AgentToolsV2 {
           header.terms || '',
           header.customer_po_number || '',
           header.vin_number || '',
+          header.vehicle_make || '',
+          header.vehicle_model || '',
+          invoiceStatus,
           subtotal,
           gst,
           total,
@@ -97,11 +127,24 @@ export class AgentToolsV2 {
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
-      const allowed = ['customer_id','sales_date','product_name','product_description','terms','subtotal','total_gst_amount','total_amount','status','estimated_cost','sequence_number','customer_po_number','vin_number','quote_id','source_quote_number'];
+      const allowed = ['customer_id','sales_date','product_name','product_description','terms','subtotal','total_gst_amount','total_amount','status','estimated_cost','sequence_number','customer_po_number','vin_number','vehicle_make','vehicle_model','invoice_status','quote_id','source_quote_number'];
       const header = patch.header || {};
+      if (Object.prototype.hasOwnProperty.call(header, 'invoice_required')) {
+        header.invoice_status = this.normalizeInvoiceStatus(header.invoice_required);
+        delete header.invoice_required;
+      }
+      if (Object.prototype.hasOwnProperty.call(header, 'invoice_status')) {
+        header.invoice_status = this.normalizeInvoiceStatus(header.invoice_status);
+      }
       if (Object.keys(header).length) {
         const fields:string[]=[]; const values:any[]=[]; let i=1;
-        for (const [k,v] of Object.entries(header)) { if (allowed.includes(k) && v!==undefined && v!==null){ fields.push(`${k}=$${i++}`); values.push(v);} }
+        for (const [k,v] of Object.entries(header)) {
+          if (allowed.includes(k) && v!==undefined && (v!==null || k === 'invoice_status')){
+            const valueToUse = k === 'invoice_status' ? this.normalizeInvoiceStatus(v) : v;
+            fields.push(`${k}=$${i++}`);
+            values.push(valueToUse);
+          }
+        }
         if (fields.length){ values.push(salesOrderId); await client.query(`UPDATE salesorderhistory SET ${fields.join(', ')}, updated_at = NOW() WHERE sales_order_id = $${i}`, values); }
       }
       if (Array.isArray(patch.lineItems)) {

--- a/soft-sme-frontend/src/pages/OpenSalesOrderDetailPage.tsx
+++ b/soft-sme-frontend/src/pages/OpenSalesOrderDetailPage.tsx
@@ -2,9 +2,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-  Typography, Box, TextField, Button, MenuItem, Stack, Autocomplete, Grid,
+  Typography, Box, TextField, Button, Stack, Autocomplete, Grid,
   Dialog, DialogTitle, DialogContent, DialogActions, Container, Paper, Alert,
-  Card, CardContent, CircularProgress, InputAdornment, Snackbar
+  Card, CardContent, CircularProgress, InputAdornment, Snackbar, FormControl,
+  FormLabel, ToggleButton, ToggleButtonGroup
 } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -15,6 +16,8 @@ import DoneAllIcon from '@mui/icons-material/DoneAll';
 import DownloadIcon from '@mui/icons-material/Download';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
 import { toast } from 'react-toastify';
 import api from '../api/axios';
 import { useAuth } from '../contexts/AuthContext';
@@ -31,6 +34,22 @@ import UnsavedChangesGuard from '../components/UnsavedChangesGuard';
 const UNIT_OPTIONS = ['Each', 'cm', 'ft', 'kg', 'pcs', 'hr', 'L'];
 type PartOption = string | { label: string; isNew?: true; inputValue?: string };
 const DEFAULT_GST_RATE = 5.0;
+
+type InvoiceStatus = '' | 'needed' | 'done';
+
+const normalizeInvoiceStatus = (value: any): InvoiceStatus => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['needed', 'need', 'required', 'pending'].includes(normalized)) return 'needed';
+    if (['done', 'complete', 'completed', 'sent'].includes(normalized)) return 'done';
+    if (['true', 't', 'yes', 'y', '1', 'on'].includes(normalized)) return 'needed';
+    if (['false', 'f', 'no', 'n', '0', 'off', ''].includes(normalized)) return '';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'needed' : '';
+  }
+  return '';
+};
 
 interface CustomerOption { label: string; id?: number; isNew?: true; }
 interface ProductOption { label: string; id?: number; description?: string; isNew?: true; }
@@ -63,10 +82,15 @@ interface SalesOrder {
   terms: string;
   estimated_cost: number | null;
   status: string;
+  customer_po_number?: string | null;
+  vin_number?: string | null;
   exported_to_qbo?: boolean;
   qbo_invoice_id?: string;
   qbo_export_date?: string;
   qbo_export_status?: string;
+  vehicle_make?: string | null;
+  vehicle_model?: string | null;
+  invoice_status?: InvoiceStatus | null;
 }
 
 interface PartsToOrderItem {
@@ -134,6 +158,13 @@ const SalesOrderDetailPage: React.FC = () => {
   const [terms, setTerms] = useState('');
   const [customerPoNumber, setCustomerPoNumber] = useState('');
   const [vinNumber, setVinNumber] = useState('');
+  const [vehicleMake, setVehicleMake] = useState('');
+  const [vehicleModel, setVehicleModel] = useState('');
+  const [invoiceStatus, setInvoiceStatus] = useState<InvoiceStatus>('');
+
+  const handleInvoiceStatusToggle = useCallback((_: React.MouseEvent<HTMLElement>, value: InvoiceStatus | null) => {
+    setInvoiceStatus(value ?? '');
+  }, []);
   const [estimatedCost, setEstimatedCost] = useState<number | null>(null);
   const [sourceQuoteNumber, setSourceQuoteNumber] = useState('');
 
@@ -215,7 +246,10 @@ const SalesOrderDetailPage: React.FC = () => {
     customerPoNumber: (customerPoNumber || '').trim(),
     vinNumber: (vinNumber || '').trim(),
     estimatedCost: estimatedCost != null ? Number(estimatedCost) : null,
-  }), [customer, product, salesDate, terms, customerPoNumber, vinNumber, estimatedCost]);
+    vehicleMake: (vehicleMake || '').trim(),
+    vehicleModel: (vehicleModel || '').trim(),
+    invoiceStatus,
+  }), [customer, product, salesDate, terms, customerPoNumber, vinNumber, estimatedCost, vehicleMake, vehicleModel, invoiceStatus]);
 
   // Set initial signature only once after data is fully loaded
   useEffect(() => {
@@ -436,7 +470,13 @@ const SalesOrderDetailPage: React.FC = () => {
       try {
         const res = await api.get(`/api/sales-orders/${id}`);
         const data = res.data;
-        setSalesOrder(data.salesOrder);
+        const normalizedStatus = normalizeInvoiceStatus(
+          data.salesOrder?.invoice_status ?? data.salesOrder?.invoice_required
+        );
+        setSalesOrder(data.salesOrder ? {
+          ...data.salesOrder,
+          invoice_status: normalizedStatus || null,
+        } : null);
         setSourceQuoteNumber(data.salesOrder?.source_quote_number || '');
 
         const li = (data.lineItems || data.salesOrder?.line_items || []).map((item: any) => ({
@@ -480,6 +520,9 @@ const SalesOrderDetailPage: React.FC = () => {
         setTerms(data.salesOrder?.terms || '');
         setCustomerPoNumber(data.salesOrder?.customer_po_number || '');
         setVinNumber(data.salesOrder?.vin_number || '');
+        setVehicleMake(data.salesOrder?.vehicle_make || '');
+        setVehicleModel(data.salesOrder?.vehicle_model || '');
+        setInvoiceStatus(normalizedStatus);
         
         // hydrate dropdown selections
         const cust = customers.find(c => c.id === data.salesOrder?.customer_id) ||
@@ -850,6 +893,9 @@ const SalesOrderDetailPage: React.FC = () => {
       terms: terms.trim(),
       customer_po_number: customerPoNumber.trim(),
       vin_number: vinNumber.trim(),
+      vehicle_make: vehicleMake.trim(),
+      vehicle_model: vehicleModel.trim(),
+      invoice_status: invoiceStatus || null,
       status: isCreationMode ? 'Open' : (salesOrder?.status || 'Open'),
       estimated_cost: estimatedCost != null ? Number(estimatedCost) : 0,
       lineItems: buildPayloadLineItems(lineItems),
@@ -888,7 +934,7 @@ const SalesOrderDetailPage: React.FC = () => {
           (window as any).__unsavedGuardAllowNext = true;
         }, 100);
         setInitialSignature(JSON.stringify({
-          header: { customer, product, salesDate, terms, customerPoNumber, vinNumber, estimatedCost },
+          header: { customer, product, salesDate, terms, customerPoNumber, vinNumber, estimatedCost, vehicleMake, vehicleModel, invoiceStatus },
           lineItems,
           quantityToOrderItems,
         }));
@@ -899,7 +945,14 @@ const SalesOrderDetailPage: React.FC = () => {
             api.get('/api/inventory')
           ]);
           const data = soRes.data;
-          setSalesOrder(data.salesOrder);
+          const refreshedStatus = normalizeInvoiceStatus(
+            data.salesOrder?.invoice_status ?? data.salesOrder?.invoice_required
+          );
+          setSalesOrder(data.salesOrder ? {
+            ...data.salesOrder,
+            invoice_status: refreshedStatus || null,
+          } : null);
+          setInvoiceStatus(refreshedStatus);
           setSourceQuoteNumber(data.salesOrder?.source_quote_number || '');
  
           const li = (data.lineItems || data.salesOrder?.line_items || []).map((item: any) => ({
@@ -1130,6 +1183,23 @@ const SalesOrderDetailPage: React.FC = () => {
               <Grid item xs={12} sm={6}><b>Customer:</b> {salesOrder.customer_name || 'N/A'}</Grid>
               <Grid item xs={12} sm={6}><b>Sales Date:</b> {salesOrder.sales_date ? new Date(salesOrder.sales_date).toLocaleDateString() : ''}</Grid>
               <Grid item xs={12} sm={6}><b>Status:</b> {salesOrder.status?.toUpperCase() || 'N/A'}</Grid>
+              <Grid item xs={12} sm={6}><b>VIN #:</b> {salesOrder.vin_number || 'N/A'}</Grid>
+              <Grid item xs={12} sm={6}><b>Make:</b> {salesOrder.vehicle_make || 'N/A'}</Grid>
+              <Grid item xs={12} sm={6}><b>Model:</b> {salesOrder.vehicle_model || 'N/A'}</Grid>
+              <Grid item xs={12} sm={6}>
+                <b>Invoice:</b>{' '}
+                {salesOrder.invoice_status === 'done' && (
+                  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+                    <CheckCircleIcon color="success" fontSize="small" /> Done
+                  </Box>
+                )}
+                {salesOrder.invoice_status === 'needed' && (
+                  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+                    <CancelIcon color="error" fontSize="small" /> Needed
+                  </Box>
+                )}
+                {!salesOrder.invoice_status && '—'}
+              </Grid>
               <Grid item xs={12}><b>Estimated Price:</b> {formatCurrency(salesOrder.estimated_cost || 0)}</Grid>
               <Grid item xs={12}><b>Product Description:</b> {salesOrder.product_description || 'N/A'}</Grid>
               <Grid item xs={12}><b>Terms:</b> {salesOrder.terms || 'N/A'}</Grid>
@@ -1227,6 +1297,7 @@ const SalesOrderDetailPage: React.FC = () => {
               setCustomer(null); setCustomerInput(''); setSalesDate(dayjs());
               setProduct(null); setProductInput(''); setProductDescription('');
               setTerms(''); setCustomerPoNumber(''); setVinNumber('');
+              setVehicleMake(''); setVehicleModel(''); setInvoiceStatus('');
               setEstimatedCost(null);
               setLineItems([{
                 part_number: '', part_description: '', quantity: '',
@@ -1462,6 +1533,72 @@ const SalesOrderDetailPage: React.FC = () => {
                 error={!!(vinNumber && vinNumber.trim() !== '' && vinNumber.trim().length !== 17)}
                 helperText={(vinNumber && vinNumber.trim() !== '' && vinNumber.trim().length !== 17) ? 'VIN must be 17 characters' : ''}
               />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="Make"
+                value={vehicleMake}
+                onChange={e => setVehicleMake(e.target.value)}
+                fullWidth
+                placeholder="Optional"
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="Model"
+                value={vehicleModel}
+                onChange={e => setVehicleModel(e.target.value)}
+                fullWidth
+                placeholder="Optional"
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <FormControl component="fieldset" fullWidth>
+                <FormLabel sx={{ mb: 1 }}>Invoice</FormLabel>
+                <ToggleButtonGroup
+                  value={invoiceStatus || null}
+                  exclusive
+                  fullWidth
+                  size="small"
+                  color="standard"
+                  aria-label="Invoice status"
+                  onChange={handleInvoiceStatusToggle}
+                  sx={{
+                    '& .MuiToggleButtonGroup-grouped': {
+                      textTransform: 'none',
+                      flex: 1,
+                      gap: 0,
+                    },
+                    '& .MuiToggleButtonGroup-grouped:not(:first-of-type)': {
+                      marginLeft: 0,
+                    },
+                    '& .MuiToggleButtonGroup-grouped.Mui-selected': {
+                      color: '#fff',
+                    },
+                    '& .MuiToggleButtonGroup-grouped.Mui-selected.MuiToggleButton-colorError': {
+                      bgcolor: (theme) => theme.palette.error.main,
+                      '&:hover': {
+                        bgcolor: (theme) => theme.palette.error.dark,
+                      },
+                    },
+                    '& .MuiToggleButtonGroup-grouped.Mui-selected.MuiToggleButton-colorSuccess': {
+                      bgcolor: (theme) => theme.palette.success.main,
+                      '&:hover': {
+                        bgcolor: (theme) => theme.palette.success.dark,
+                      },
+                    },
+                  }}
+                >
+                  <ToggleButton value="needed" color="error">
+                    <CancelIcon fontSize="small" sx={{ mr: 1 }} />
+                    Needed
+                  </ToggleButton>
+                  <ToggleButton value="done" color="success">
+                    <CheckCircleIcon fontSize="small" sx={{ mr: 1 }} />
+                    Done
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </FormControl>
             </Grid>
             <Grid item xs={12} sm={4}>
               <DatePicker

--- a/soft-sme-frontend/src/pages/OpenSalesOrdersPage.tsx
+++ b/soft-sme-frontend/src/pages/OpenSalesOrdersPage.tsx
@@ -23,9 +23,24 @@ import PrintIcon from '@mui/icons-material/Print';
 import ReplayIcon from '@mui/icons-material/Replay';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
+import CancelIcon from '@mui/icons-material/Cancel';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { InputAdornment } from '@mui/material';
 import { parseNumericInput } from '../utils/salesOrderCalculations';
+
+const normalizeInvoiceStatus = (value: any): '' | 'needed' | 'done' => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['needed', 'need', 'required', 'pending'].includes(normalized)) return 'needed';
+    if (['done', 'complete', 'completed', 'sent'].includes(normalized)) return 'done';
+    if (['true', 't', 'yes', 'y', '1', 'on'].includes(normalized)) return 'needed';
+    if (['false', 'f', 'no', 'n', '0', 'off', ''].includes(normalized)) return '';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'needed' : '';
+  }
+  return '';
+};
 
 const OpenSalesOrdersPage: React.FC = () => {
   const [search, setSearch] = useState('');
@@ -75,6 +90,7 @@ const OpenSalesOrdersPage: React.FC = () => {
         subtotal: Number(order.subtotal) || 0,
         total_gst_amount: Number(order.total_gst_amount) || 0,
         total_amount: Number(order.total_amount) || 0,
+        invoice_status: normalizeInvoiceStatus(order.invoice_status ?? order.invoice_required),
       }));
       setRows(ordersWithId);
 
@@ -294,17 +310,37 @@ const OpenSalesOrdersPage: React.FC = () => {
     { field: 'product_name', headerName: 'Product Name', flex: 1, minWidth: 120 },
     { field: 'product_description', headerName: 'Product Description', flex: 1.5, minWidth: 150 },
     { field: 'subtotal', headerName: 'Subtotal', flex: 0.8, minWidth: 100, valueFormatter: (params) => params.value != null && !isNaN(Number(params.value)) ? `$${Number(params.value).toFixed(2)}` : '$0.00' },
-    { field: 'total_gst_amount', headerName: 'GST', flex: 0.7, minWidth: 80, valueFormatter: (params) => params.value != null && !isNaN(Number(params.value)) ? `$${Number(params.value).toFixed(2)}` : '$0.00' },
     { field: 'total_amount', headerName: 'Total', flex: 0.8, minWidth: 100, valueFormatter: (params) => params.value != null && !isNaN(Number(params.value)) ? `$${Number(params.value).toFixed(2)}` : '$0.00' },
-    { field: 'status', headerName: 'Status', flex: 0.8, minWidth: 100, 
+    { field: 'status', headerName: 'Status', flex: 0.8, minWidth: 100,
       renderCell: (params) => (
-        <Chip 
-          label={params.value} 
+        <Chip
+          label={params.value}
           color={params.value === 'Open' ? 'success' : 'error'}
           size="small"
           variant="outlined"
         />
       )
+    },
+    {
+      field: 'invoice_status',
+      headerName: 'Invoice',
+      flex: 0.6,
+      minWidth: 90,
+      valueFormatter: (params) => {
+        if (params.value === 'done') return 'Done';
+        if (params.value === 'needed') return 'Needed';
+        return '';
+      },
+      renderCell: (params) => {
+        if (params.value === 'done') {
+          return <CheckCircleIcon color="success" titleAccess="Invoice done" />;
+        }
+        if (params.value === 'needed') {
+          return <CancelIcon color="error" titleAccess="Invoice needed" />;
+        }
+        return null;
+      },
+      sortable: false,
     },
     {
       field: 'exported_to_qbo',


### PR DESCRIPTION
## Summary
- replace the invoice status button group with a toggle button group so both Needed and Done choices always render side by side
- wire the toggle handler to allow clearing the selection by re-clicking the active option while keeping the color-coded icons

## Testing
- CI=1 npm --prefix soft-sme-frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e3308e89348324bb836dbf1ff46b05