### PR TITLE
Add vehicle make/model support to quotes

### DIFF
--- a/soft-sme-backend/src/services/pdfService.ts
+++ b/soft-sme-backend/src/services/pdfService.ts
@@ -387,6 +387,16 @@ export class PDFService {
           doc.font('Helvetica').fontSize(11).fillColor('#000000').text(quote.vin_number, 170, y);
           y += 16;
         }
+        if (quote.vehicle_make && quote.vehicle_make.trim() !== '') {
+          doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Make:', 50, y);
+          doc.font('Helvetica').fontSize(11).fillColor('#000000').text(quote.vehicle_make, 170, y);
+          y += 16;
+        }
+        if (quote.vehicle_model && quote.vehicle_model.trim() !== '') {
+          doc.font('Helvetica-Bold').fontSize(11).fillColor('#000000').text('Model:', 50, y);
+          doc.font('Helvetica').fontSize(11).fillColor('#000000').text(quote.vehicle_model, 170, y);
+          y += 16;
+        }
         y += 8;
         // Horizontal line
         doc.moveTo(50, y).lineTo(550, y).strokeColor('#444444').lineWidth(1).stroke();

--- a/soft-sme-frontend/src/pages/QuoteEditorPage.tsx
+++ b/soft-sme-frontend/src/pages/QuoteEditorPage.tsx
@@ -59,6 +59,8 @@ interface Quote {
   terms?: string;
   customer_po_number?: string;
   vin_number?: string;
+  vehicle_make?: string;
+  vehicle_model?: string;
 }
 
 const formatInt = (v: number | string | null | undefined) => {
@@ -125,6 +127,8 @@ const QuoteEditorPage: React.FC = () => {
   const [terms, setTerms] = useState('');
   const [customerPoNumber, setCustomerPoNumber] = useState('');
   const [vinNumber, setVinNumber] = useState('');
+  const [vehicleMake, setVehicleMake] = useState('');
+  const [vehicleModel, setVehicleModel] = useState('');
 
   // ui
   const [loading, setLoading] = useState(false);
@@ -167,7 +171,9 @@ const QuoteEditorPage: React.FC = () => {
     terms: (terms || '').trim(),
     customerPoNumber: (customerPoNumber || '').trim(),
     vinNumber: (vinNumber || '').trim(),
-  }), [selectedCustomer, quote, selectedProduct, quoteDate, validUntil, estimatedCost, productDescription, terms, customerPoNumber, vinNumber]);
+    vehicleMake: (vehicleMake || '').trim(),
+    vehicleModel: (vehicleModel || '').trim(),
+  }), [selectedCustomer, quote, selectedProduct, quoteDate, validUntil, estimatedCost, productDescription, terms, customerPoNumber, vinNumber, vehicleMake, vehicleModel]);
   
   // Set initial signature only once after data is fully loaded
   useEffect(() => {
@@ -222,6 +228,8 @@ const QuoteEditorPage: React.FC = () => {
         setTerms(q.terms || '');
         setCustomerPoNumber(q.customer_po_number || '');
         setVinNumber(q.vin_number || '');
+        setVehicleMake(q.vehicle_make || '');
+        setVehicleModel(q.vehicle_model || '');
         setCustomerInput(q.customer_name || '');
         setProductInput(q.product_name || '');
         setIsDataLoaded(true); // Mark data as loaded
@@ -294,6 +302,8 @@ const QuoteEditorPage: React.FC = () => {
     setTerms('');
     setCustomerPoNumber('');
     setVinNumber('');
+    setVehicleMake('');
+    setVehicleModel('');
     setCustomerInput('');
     setProductInput('');
   };
@@ -317,6 +327,8 @@ const QuoteEditorPage: React.FC = () => {
         terms,
         customer_po_number: customerPoNumber,
         vin_number: vinNumber,
+        vehicle_make: vehicleMake.trim(),
+        vehicle_model: vehicleModel.trim(),
       };
 
       if (isEditMode && quote) {
@@ -358,6 +370,8 @@ const QuoteEditorPage: React.FC = () => {
             terms: payload.terms,
             customer_po_number: payload.customer_po_number,
             vin_number: payload.vin_number,
+            vehicle_make: payload.vehicle_make,
+            vehicle_model: payload.vehicle_model,
           };
           setQuote(newQuote);
           // jump to edit URL for the new quote
@@ -757,6 +771,30 @@ const QuoteEditorPage: React.FC = () => {
                   InputLabelProps={{ sx: labelSx }}
                   error={vinNumber.length > 0 && vinNumber.length !== 17}
                   helperText={vinNumber.length > 0 && vinNumber.length !== 17 ? 'VIN must be 17 characters' : ''}
+                />
+              </Grid>
+
+              {/* Vehicle Make */}
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Make"
+                  fullWidth
+                  value={vehicleMake}
+                  onChange={(e) => setVehicleMake(e.target.value)}
+                  sx={input56Sx}
+                  InputLabelProps={{ sx: labelSx }}
+                />
+              </Grid>
+
+              {/* Vehicle Model */}
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Model"
+                  fullWidth
+                  value={vehicleModel}
+                  onChange={(e) => setVehicleModel(e.target.value)}
+                  sx={input56Sx}
+                  InputLabelProps={{ sx: labelSx }}
                 />
               </Grid>
 

--- a/soft-sme-frontend/src/pages/QuotePage.tsx
+++ b/soft-sme-frontend/src/pages/QuotePage.tsx
@@ -43,6 +43,8 @@ interface Quote {
   terms?: string;
   customer_po_number?: string;
   vin_number?: string;
+  vehicle_make?: string;
+  vehicle_model?: string;
 }
 
 const formatInt = (v: number | string | null | undefined) => {
@@ -92,6 +94,8 @@ const QuotePage: React.FC = () => {
       'Quote #': q.quote_number,
       Customer: q.customer_name,
       Product: q.product_name,
+      Make: q.vehicle_make || '',
+      Model: q.vehicle_model || '',
       'Est. Price': formatInt(q.estimated_cost),
       'Quote Date': q.quote_date ? format(new Date(q.quote_date), 'MM/dd/yyyy') : '',
       'Valid Until': q.valid_until ? format(new Date(q.valid_until), 'MM/dd/yyyy') : '',
@@ -115,7 +119,9 @@ const QuotePage: React.FC = () => {
         (q) =>
           q.quote_number?.toLowerCase?.().includes(searchTerm.toLowerCase()) ||
           q.customer_name?.toLowerCase?.().includes(searchTerm.toLowerCase()) ||
-          q.product_name?.toLowerCase?.().includes(searchTerm.toLowerCase())
+          q.product_name?.toLowerCase?.().includes(searchTerm.toLowerCase()) ||
+          q.vehicle_make?.toLowerCase?.().includes(searchTerm.toLowerCase()) ||
+          q.vehicle_model?.toLowerCase?.().includes(searchTerm.toLowerCase())
       ),
     [quotes, searchTerm]
   );
@@ -126,6 +132,8 @@ const QuotePage: React.FC = () => {
     { field: 'quote_number', headerName: 'Quote #', flex: 1.05, minWidth: 150, valueFormatter: (params) => params.value ? String(params.value).replace('QO-', '') : '' },
     { field: 'customer_name', headerName: 'Customer', flex: 1.2, minWidth: 170 },
     { field: 'product_name', headerName: 'Product', flex: 1.1, minWidth: 160 },
+    { field: 'vehicle_make', headerName: 'Make', flex: 0.9, minWidth: 130 },
+    { field: 'vehicle_model', headerName: 'Model', flex: 0.9, minWidth: 130 },
     {
       field: 'estimated_cost',
       headerName: 'Est. Price',


### PR DESCRIPTION
## Summary
- add vehicle make and model fields to quote create/update APIs and ensure they flow into sales orders
- update quote PDFs and agent tools to include the new vehicle details
- extend the quote editor and list UI to capture, display, and export vehicle make/model information

## Testing
- npm --prefix soft-sme-backend run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e191ace08324bd765e783ee49360