### PR TITLE
Allow Sales and Purchase role to access closed purchase orders

### DIFF
--- a/soft-sme-frontend/src/App.tsx
+++ b/soft-sme-frontend/src/App.tsx
@@ -75,13 +75,19 @@ const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => 
       '/',
       '/open-sales-orders',
       '/open-purchase-orders',
+      '/purchase-order',
       '/parts-to-order',
       '/inventory',
       '/supply',
       '/email-settings',
     ];
-    // Allow paths that start with /open-sales-orders/, /open-purchase-orders/ (for detail pages)
-    if (!allowed.includes(path) && !path.startsWith('/open-sales-orders/') && !path.startsWith('/open-purchase-orders/')) {
+    // Allow paths that start with /open-sales-orders/, /open-purchase-orders/, /purchase-order/ (for detail pages)
+    if (
+      !allowed.includes(path) &&
+      !path.startsWith('/open-sales-orders/') &&
+      !path.startsWith('/open-purchase-orders/') &&
+      !path.startsWith('/purchase-order/')
+    ) {
       return <Navigate to="/" replace />;
     }
   }


### PR DESCRIPTION
## Summary
- allow the Sales and Purchase access role to navigate to closed purchase order routes by whitelisting /purchase-order paths in the private route guard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e38ddb0083248d40d3966012f853