### PR TITLE
Add centered success dialogs after clocking actions

### DIFF
--- a/soft-sme-frontend/src/pages/AttendancePage.tsx
+++ b/soft-sme-frontend/src/pages/AttendancePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Container,
@@ -52,6 +52,27 @@ const AttendancePage: React.FC = () => {
   const [newProfile, setNewProfile] = useState({ name: '', email: '' });
 
   const [showUnclosedWarning, setShowUnclosedWarning] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const successTimeoutRef = useRef<number | null>(null);
+
+  const showSuccess = (message: string) => {
+    if (successTimeoutRef.current) {
+      window.clearTimeout(successTimeoutRef.current);
+    }
+    setSuccessMessage(message);
+    successTimeoutRef.current = window.setTimeout(() => {
+      setSuccessMessage(null);
+      successTimeoutRef.current = null;
+    }, 2500);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) {
+        window.clearTimeout(successTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     fetchData();
@@ -112,6 +133,7 @@ const AttendancePage: React.FC = () => {
       // Reset profile selection without reloading page
       setSelectedProfile('');
       setShifts([]);
+      showSuccess('Successfully clocked in.');
     } catch (err) {
       setError('Failed to clock in. Please try again.');
       console.error('Error clocking in:', err);
@@ -126,6 +148,7 @@ const AttendancePage: React.FC = () => {
       // Reset profile selection without reloading page
       setSelectedProfile('');
       setShifts([]);
+      showSuccess('Successfully clocked out.');
     } catch (err) {
       setError('Failed to clock out. Please try again.');
       console.error('Error clocking out:', err);
@@ -185,6 +208,24 @@ const AttendancePage: React.FC = () => {
           You have an unclosed shift from a previous day. Please clock out before starting a new shift.
         </Alert>
       )}
+      <Dialog
+        open={Boolean(successMessage)}
+        onClose={() => setSuccessMessage(null)}
+        PaperProps={{
+          sx: {
+            px: 6,
+            py: 4,
+            textAlign: 'center'
+          }
+        }}
+      >
+        <DialogTitle sx={{ fontSize: '2rem' }}>Success</DialogTitle>
+        <DialogContent>
+          <Typography variant="h4" component="p">
+            {successMessage}
+          </Typography>
+        </DialogContent>
+      </Dialog>
 
       <Grid container spacing={3}>
         {/* Profile Selection */}

--- a/soft-sme-frontend/src/pages/TimeTrackingPage.tsx
+++ b/soft-sme-frontend/src/pages/TimeTrackingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Container,
@@ -50,6 +50,27 @@ const TimeTrackingPage: React.FC = () => {
   const [selectedSO, setSelectedSO] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const successTimeoutRef = useRef<number | null>(null);
+
+  const showSuccess = (message: string) => {
+    if (successTimeoutRef.current) {
+      window.clearTimeout(successTimeoutRef.current);
+    }
+    setSuccessMessage(message);
+    successTimeoutRef.current = window.setTimeout(() => {
+      setSuccessMessage(null);
+      successTimeoutRef.current = null;
+    }, 2500);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) {
+        window.clearTimeout(successTimeoutRef.current);
+      }
+    };
+  }, []);
 
   
 
@@ -147,6 +168,7 @@ const TimeTrackingPage: React.FC = () => {
       setSelectedSO('');
       setTimeEntries([]);
       setError(null);
+      showSuccess('Successfully clocked in.');
     } catch (err: any) {
       if (err.response && err.response.data && err.response.data.error.includes('attendance')) {
         setError('You must clock in for attendance before you can clock in for a sales order.');
@@ -168,6 +190,7 @@ const TimeTrackingPage: React.FC = () => {
       setSelectedSO('');
       setTimeEntries([]);
       setError(null);
+      showSuccess('Successfully clocked out.');
     } catch (err) {
       setError('Failed to clock out. Please try again.');
       console.error('Error clocking out:', err);
@@ -201,6 +224,24 @@ const TimeTrackingPage: React.FC = () => {
           {error}
         </Alert>
       )}
+      <Dialog
+        open={Boolean(successMessage)}
+        onClose={() => setSuccessMessage(null)}
+        PaperProps={{
+          sx: {
+            px: 6,
+            py: 4,
+            textAlign: 'center'
+          }
+        }}
+      >
+        <DialogTitle sx={{ fontSize: '2rem' }}>Success</DialogTitle>
+        <DialogContent>
+          <Typography variant="h4" component="p">
+            {successMessage}
+          </Typography>
+        </DialogContent>
+      </Dialog>
 
       <Grid container spacing={3}>
         {/* Profile Selection */}


### PR DESCRIPTION
## Summary
- show a centered success dialog after clocking in or out on the time tracking page
- reuse the success dialog pattern for attendance clock in/out actions so users receive confirmation

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file in soft-sme-frontend/electron)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e4fb2180832481fe0c94e153a0c4