### PR TITLE
Add shift and time entry deletion to time tracking reports

### DIFF
--- a/soft-sme-frontend/src/services/attendanceService.ts
+++ b/soft-sme-frontend/src/services/attendanceService.ts
@@ -98,3 +98,7 @@ export const getShiftsInRange = async (profileId: number, from: string, to: stri
   const response = await api.get('/api/attendance', { params: { profile_id: profileId, from, to } });
   return response.data;
 };
+
+export const deleteShift = async (shiftId: number): Promise<void> => {
+  await api.delete(`/api/attendance/${shiftId}`);
+};

--- a/soft-sme-frontend/src/services/timeTrackingService.ts
+++ b/soft-sme-frontend/src/services/timeTrackingService.ts
@@ -155,6 +155,10 @@ export const updateTimeEntry = async (id: number, clock_in: string, clock_out: s
   return response.data;
 };
 
+export const deleteTimeEntry = async (id: number): Promise<void> => {
+  await api.delete(`/api/time-tracking/time-entries/${id}`);
+};
+
 export const createTimeEntry = async (profileId: number, salesOrderId: number, clockInISO: string, clockOutISO: string): Promise<TimeEntry> => {
   const response = await api.post('/api/time-tracking/time-entries/manual', {
     profile_id: profileId,


### PR DESCRIPTION
## Summary
- add a reusable helper to recalculate labour, overhead, and supply line items when time entries change
- expose delete endpoints for time entries and attendance shifts that reuse the shared recalculation logic
- allow deleting shifts and individual time entries from the time tracking reports UI with confirmation dialogs, and refresh the report afterwards
- add frontend service helpers for the new delete APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ec7a571c8324bf413c05ec55f8a2