### PR TITLE
Fix timezone-aware break deductions in time tracking

### DIFF
--- a/soft-sme-frontend/src/api/axios.ts
+++ b/soft-sme-frontend/src/api/axios.ts
@@ -21,7 +21,16 @@ api.interceptors.request.use(
     if (deviceId) {
       config.headers['x-device-id'] = deviceId;
     }
-    
+
+    try {
+      const timeZone = typeof Intl !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : undefined;
+      if (timeZone) {
+        config.headers['x-timezone'] = timeZone;
+      }
+    } catch {
+      // Ignore timezone resolution errors and skip header when unavailable
+    }
+
     return config;
   },
   (error) => {


### PR DESCRIPTION
## Summary
- ensure time tracking and attendance break calculations reconstruct break windows in the request timezone so UTC-stored shifts deduct lunch correctly
- forward the browser's timezone to the API via the x-timezone header to let the server resolve break times consistently

## Testing
- npm run build (backend)


------
https://chatgpt.com/codex/tasks/task_e_68e40fcf23408324a51e2f2e9953cacc