### PR TITLE
Allow x-timezone header in CORS configuration

### DIFF
--- a/soft-sme-backend/src/app.ts
+++ b/soft-sme-backend/src/app.ts
@@ -81,7 +81,7 @@ const corsOptions: cors.CorsOptions = {
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'x-device-id'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'x-device-id', 'x-timezone'],
   optionsSuccessStatus: 204,
 };
 


### PR DESCRIPTION
## Summary
- allow the backend to accept the x-timezone header in CORS preflight checks so frontend logins succeed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e427a9a7b08324b8dab3a7b5a739a9