### PR TITLE
Document messaging migration SQL and add timestamp triggers

### DIFF
--- a/soft-sme-backend/migrations/20250301_create_messaging_tables.sql
+++ b/soft-sme-backend/migrations/20250301_create_messaging_tables.sql
@@ -1,0 +1,89 @@
+-- Messaging tables for direct and group conversations
+-- Supports multi-tenant access via company_id and enforces participant membership
+
+CREATE TABLE IF NOT EXISTS conversations (
+  id BIGSERIAL PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES companies(id),
+  conversation_type VARCHAR(20) NOT NULL CHECK (conversation_type IN ('direct', 'group')),
+  title VARCHAR(255),
+  created_by INTEGER NOT NULL REFERENCES users(id),
+  last_message_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_company ON conversations(company_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_last_message ON conversations(last_message_at DESC NULLS LAST);
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  is_admin BOOLEAN DEFAULT FALSE,
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'conversation_participants_unique'
+  ) THEN
+    ALTER TABLE conversation_participants
+      ADD CONSTRAINT conversation_participants_unique UNIQUE (conversation_id, user_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_user ON conversation_participants(user_id);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  sender_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  content TEXT NOT NULL,
+  attachments JSONB,
+  is_system BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
+
+-- Ensure there is a shared trigger helper for updated_at maintenance
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'update_conversations_updated_at'
+  ) THEN
+    CREATE TRIGGER update_conversations_updated_at
+      BEFORE UPDATE ON conversations
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'update_messages_updated_at'
+  ) THEN
+    CREATE TRIGGER update_messages_updated_at
+      BEFORE UPDATE ON messages
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;

--- a/soft-sme-backend/migrations/README.md
+++ b/soft-sme-backend/migrations/README.md
@@ -76,3 +76,114 @@ The frontend has been updated to:
 - Show only supply items on the new Supply page
 - Include part_type field in add/edit forms
 - Default to appropriate part_type based on the page context 
+## Messaging Tables for Direct and Group Chats
+
+### Migration Files
+
+- **`20250301_create_messaging_tables.sql`** – creates `conversations`, `conversation_participants`, and `messages` tables with supporting indexes and constraints for multi-tenant chat.
+
+### What the Migration Does
+
+1. **`conversations` table** – stores chat metadata including the company, creator, type (`direct` or `group`), timestamps, and `last_message_at` to make sorting efficient.
+2. **`conversation_participants` table** – links users to conversations, enforces uniqueness per conversation, and tracks whether a participant is an admin.
+3. **`messages` table** – stores conversation messages with optional JSONB attachments, sender references, and indexes for quick history lookups.
+
+### Running the Migration
+
+You can run the migration through pgAdmin or via psql:
+
+```bash
+psql -U <user> -d <database> -f 20250301_create_messaging_tables.sql
+```
+
+The script is idempotent; unique constraints and tables are only created if they do not already exist, so it is safe to rerun if needed.
+
+### SQL to run in pgAdmin
+
+If you prefer to execute the raw SQL in pgAdmin's query tool, paste the following snippet which mirrors the migration file:
+
+```sql
+-- Conversations store group and direct chat metadata
+CREATE TABLE IF NOT EXISTS conversations (
+  id BIGSERIAL PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES companies(id),
+  conversation_type VARCHAR(20) NOT NULL CHECK (conversation_type IN ('direct', 'group')),
+  title VARCHAR(255),
+  created_by INTEGER NOT NULL REFERENCES users(id),
+  last_message_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_company ON conversations(company_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_last_message ON conversations(last_message_at DESC NULLS LAST);
+
+-- Participants connect users to conversations
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  is_admin BOOLEAN DEFAULT FALSE,
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'conversation_participants_unique'
+  ) THEN
+    ALTER TABLE conversation_participants
+      ADD CONSTRAINT conversation_participants_unique UNIQUE (conversation_id, user_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_user ON conversation_participants(user_id);
+
+-- Messages capture chat history
+CREATE TABLE IF NOT EXISTS messages (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  sender_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  content TEXT NOT NULL,
+  attachments JSONB,
+  is_system BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
+
+-- Maintain updated_at timestamps automatically
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_conversations_updated_at'
+  ) THEN
+    CREATE TRIGGER update_conversations_updated_at
+      BEFORE UPDATE ON conversations
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'update_messages_updated_at'
+  ) THEN
+    CREATE TRIGGER update_messages_updated_at
+      BEFORE UPDATE ON messages
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+```

--- a/soft-sme-backend/src/app.ts
+++ b/soft-sme-backend/src/app.ts
@@ -25,6 +25,7 @@ import attendanceRouter from './routes/attendanceRoutes';
 import aiAssistantRouter from './routes/aiAssistantRoutes';
 import emailRouter from './routes/emailRoutes';
 import profileDocumentRouter from './routes/profileDocumentRoutes';
+import messagingRouter from './routes/messagingRoutes';
 
 import chatRouter from './routes/chatRoutes';
 
@@ -176,6 +177,9 @@ console.log('Registered attendance routes');
 
 app.use('/api/profile-documents', profileDocumentRouter);
 console.log('Registered profile document routes');
+
+app.use('/api/messaging', authMiddleware, messagingRouter);
+console.log('Registered messaging routes');
 
 app.use('/api/settings', authMiddleware, globalSettingsRouter);
 console.log('Registered global settings routes');

--- a/soft-sme-backend/src/index.ts
+++ b/soft-sme-backend/src/index.ts
@@ -38,6 +38,7 @@ import overheadRoutes from './routes/overheadRoutes';
 import aiAssistantRoutes from './routes/aiAssistantRoutes';
 import emailRoutes from './routes/emailRoutes';
 import profileDocumentRoutes from './routes/profileDocumentRoutes';
+import messagingRoutes from './routes/messagingRoutes';
 import agentV2Routes from './routes/agentV2Routes';
 import voiceRoutes from './routes/voiceRoutes';
 import voiceStreamRoutes from './routes/voiceStreamRoutes';
@@ -183,6 +184,9 @@ console.log('Registered email routes');
 // Profile document routes
 app.use('/api/profile-documents', profileDocumentRoutes);
 console.log('Registered profile document routes');
+
+app.use('/api/messaging', authMiddleware, messagingRoutes);
+console.log('Registered messaging routes');
 
 // Agent V2 routes (feature-flagged)
 if (process.env.AI_ASSISTANT_V2 !== 'false') {

--- a/soft-sme-backend/src/routes/messagingRoutes.ts
+++ b/soft-sme-backend/src/routes/messagingRoutes.ts
@@ -1,0 +1,129 @@
+import express, { Request, Response } from 'express';
+import { messagingService } from '../services/messagingService';
+
+const router = express.Router();
+
+router.post('/conversations', async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Not authenticated' });
+    }
+
+    const userId = Number(req.user.id);
+    const companyId = Number(req.user.company_id);
+
+    if (!Number.isInteger(userId) || !Number.isInteger(companyId)) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const { participantIds, title, type } = req.body ?? {};
+    const participantsArray = Array.isArray(participantIds)
+      ? participantIds
+          .map((id: any) => Number(id))
+          .filter((id: number) => Number.isInteger(id) && id > 0)
+      : [];
+
+    const normalizedType = type === 'group' || type === 'direct' ? type : undefined;
+
+    const result = await messagingService.createConversation({
+      companyId,
+      createdBy: userId,
+      participantIds: participantsArray,
+      title: typeof title === 'string' ? title : undefined,
+      type: normalizedType,
+    });
+
+    const status = result.created ? 201 : 200;
+    return res.status(status).json({ conversation: result.conversation, created: result.created });
+  } catch (error) {
+    console.error('Failed to create conversation', error);
+    const status = (error as any)?.status ?? 500;
+    const message = (error as Error).message || 'Unable to create conversation';
+    return res.status(status).json({ message });
+  }
+});
+
+router.get('/conversations', async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Not authenticated' });
+    }
+
+    const userId = Number(req.user.id);
+    const companyId = Number(req.user.company_id);
+
+    if (!Number.isInteger(userId) || !Number.isInteger(companyId)) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const conversations = await messagingService.getUserConversations(userId, companyId);
+    return res.json({ conversations });
+  } catch (error) {
+    console.error('Failed to list conversations', error);
+    return res.status(500).json({ message: 'Unable to fetch conversations' });
+  }
+});
+
+router.post('/conversations/:conversationId/messages', async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Not authenticated' });
+    }
+
+    const conversationId = Number(req.params.conversationId);
+    const userId = Number(req.user.id);
+
+    if (!Number.isInteger(conversationId)) {
+      return res.status(400).json({ message: 'Invalid conversation id' });
+    }
+
+    if (!Number.isInteger(userId)) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const { content } = req.body ?? {};
+    if (typeof content !== 'string') {
+      return res.status(400).json({ message: 'Message content is required' });
+    }
+
+    const message = await messagingService.appendMessage(conversationId, userId, content);
+    return res.status(201).json({ message });
+  } catch (error) {
+    console.error('Failed to send message', error);
+    const status = (error as any)?.status ?? 500;
+    const message = (error as Error).message || 'Unable to send message';
+    return res.status(status).json({ message });
+  }
+});
+
+router.get('/conversations/:conversationId/messages', async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Not authenticated' });
+    }
+
+    const conversationId = Number(req.params.conversationId);
+    const userId = Number(req.user.id);
+
+    if (!Number.isInteger(conversationId)) {
+      return res.status(400).json({ message: 'Invalid conversation id' });
+    }
+
+    if (!Number.isInteger(userId)) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const limit = req.query.limit ? Number(req.query.limit) : undefined;
+    const before = typeof req.query.before === 'string' ? req.query.before : undefined;
+
+    const messages = await messagingService.getConversationMessages(conversationId, userId, { limit, before });
+    return res.json({ messages });
+  } catch (error) {
+    console.error('Failed to fetch messages', error);
+    const status = (error as any)?.status ?? 500;
+    const message = (error as Error).message || 'Unable to fetch messages';
+    return res.status(status).json({ message });
+  }
+});
+
+export default router;

--- a/soft-sme-backend/src/services/messagingService.ts
+++ b/soft-sme-backend/src/services/messagingService.ts
@@ -1,0 +1,405 @@
+import { Pool, PoolClient } from 'pg';
+import { pool } from '../db';
+
+export interface ConversationParticipant {
+  id: number;
+  username: string | null;
+  email: string | null;
+  isAdmin: boolean;
+}
+
+export interface MessageDTO {
+  id: number;
+  conversationId: number;
+  senderId: number | null;
+  senderName: string | null;
+  content: string;
+  isSystem: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConversationDTO {
+  id: number;
+  companyId: number;
+  conversationType: 'direct' | 'group';
+  title: string | null;
+  createdBy: number;
+  createdAt: string;
+  updatedAt: string;
+  lastMessageAt: string | null;
+  participants: ConversationParticipant[];
+  lastMessage: MessageDTO | null;
+}
+
+interface CreateConversationInput {
+  companyId: number;
+  createdBy: number;
+  participantIds: number[];
+  title?: string | null;
+  type?: 'direct' | 'group';
+}
+
+class MessagingService {
+  constructor(private readonly db: Pool) {}
+
+  private async withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.db.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await fn(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private mapConversation(row: any): ConversationDTO {
+    const participantsRaw = row.participant_list || [];
+    const participants: ConversationParticipant[] = Array.isArray(participantsRaw)
+      ? participantsRaw.map((participant: any) => ({
+          id: typeof participant.id === 'number' ? participant.id : Number(participant.id),
+          username: participant.username ?? null,
+          email: participant.email ?? null,
+          isAdmin: Boolean(participant.isAdmin ?? participant.is_admin ?? false)
+        }))
+      : [];
+
+    const lastMessage: MessageDTO | null = row.last_message_id
+      ? {
+          id: Number(row.last_message_id),
+          conversationId: Number(row.id),
+          senderId: row.last_message_sender_id !== null && row.last_message_sender_id !== undefined
+            ? Number(row.last_message_sender_id)
+            : null,
+          senderName: row.last_message_sender_username || row.last_message_sender_email || null,
+          content: row.last_message_content,
+          isSystem: Boolean(row.last_message_is_system),
+          createdAt: row.last_message_created_at,
+          updatedAt: row.last_message_created_at,
+        }
+      : null;
+
+    return {
+      id: Number(row.id),
+      companyId: Number(row.company_id),
+      conversationType: row.conversation_type,
+      title: row.title,
+      createdBy: Number(row.created_by),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastMessageAt: row.last_message_at,
+      participants,
+      lastMessage,
+    };
+  }
+
+  private mapMessage(row: any): MessageDTO {
+    return {
+      id: Number(row.id),
+      conversationId: Number(row.conversation_id),
+      senderId: row.sender_id !== null && row.sender_id !== undefined ? Number(row.sender_id) : null,
+      senderName: row.username || row.email || null,
+      content: row.content,
+      isSystem: Boolean(row.is_system),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private async fetchConversationById(conversationId: number, client?: PoolClient): Promise<ConversationDTO | null> {
+    const executor = client ?? this.db;
+    const result = await executor.query(
+      `SELECT
+         c.id,
+         c.company_id,
+         c.conversation_type,
+         c.title,
+         c.created_by,
+         c.last_message_at,
+         c.created_at,
+         c.updated_at,
+         participants.participant_list,
+         last_message.id AS last_message_id,
+         last_message.content AS last_message_content,
+         last_message.sender_id AS last_message_sender_id,
+         last_message.created_at AS last_message_created_at,
+         last_message.is_system AS last_message_is_system,
+         last_sender.username AS last_message_sender_username,
+         last_sender.email AS last_message_sender_email
+       FROM conversations c
+       LEFT JOIN LATERAL (
+         SELECT jsonb_agg(
+           jsonb_build_object(
+             'id', u.id,
+             'username', u.username,
+             'email', u.email,
+             'isAdmin', cp.is_admin
+           ) ORDER BY u.username
+         ) AS participant_list
+         FROM conversation_participants cp
+         LEFT JOIN users u ON u.id = cp.user_id
+         WHERE cp.conversation_id = c.id
+       ) AS participants ON TRUE
+       LEFT JOIN LATERAL (
+         SELECT m.id, m.content, m.sender_id, m.created_at, m.is_system
+         FROM messages m
+         WHERE m.conversation_id = c.id
+         ORDER BY m.created_at DESC
+         LIMIT 1
+       ) AS last_message ON TRUE
+       LEFT JOIN users last_sender ON last_sender.id = last_message.sender_id
+       WHERE c.id = $1`,
+      [conversationId]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapConversation(result.rows[0]);
+  }
+
+  private async ensureParticipant(conversationId: number, userId: number, client?: PoolClient): Promise<void> {
+    const executor = client ?? this.db;
+    const membership = await executor.query(
+      `SELECT 1
+       FROM conversation_participants
+       WHERE conversation_id = $1 AND user_id = $2`,
+      [conversationId, userId]
+    );
+
+    if (membership.rows.length === 0) {
+      const error = new Error('You are not a participant in this conversation.');
+      (error as any).status = 403;
+      throw error;
+    }
+  }
+
+  private sanitizeParticipantIds(ids: number[], creatorId: number): number[] {
+    const deduped = Array.from(new Set(ids.filter((id) => Number.isInteger(id) && id > 0)));
+    return deduped.filter((id) => id !== creatorId);
+  }
+
+  async createConversation(input: CreateConversationInput): Promise<{ conversation: ConversationDTO; created: boolean }> {
+    return this.withTransaction(async (dbClient) => {
+      const participantIds = this.sanitizeParticipantIds(input.participantIds, input.createdBy);
+      if (participantIds.length === 0) {
+        const error = new Error('At least one additional participant is required.');
+        (error as any).status = 400;
+        throw error;
+      }
+
+      const allParticipantIds = Array.from(new Set([...participantIds, input.createdBy]));
+      const conversationType: 'direct' | 'group' = input.type
+        ? input.type
+        : participantIds.length > 1
+          ? 'group'
+          : 'direct';
+
+      if (conversationType === 'group' && !input.title?.trim()) {
+        const error = new Error('Group conversations require a title.');
+        (error as any).status = 400;
+        throw error;
+      }
+
+      const validParticipants = await dbClient.query(
+        `SELECT id
+         FROM users
+         WHERE company_id = $1 AND id = ANY($2::int[])`,
+        [input.companyId, allParticipantIds]
+      );
+
+      if (validParticipants.rows.length !== allParticipantIds.length) {
+        const error = new Error('One or more participants do not belong to your company.');
+        (error as any).status = 400;
+        throw error;
+      }
+
+      if (conversationType === 'direct') {
+        const sortedIds = [...allParticipantIds].sort((a, b) => a - b);
+        const existing = await dbClient.query(
+          `SELECT c.id
+           FROM conversations c
+           JOIN conversation_participants cp ON cp.conversation_id = c.id
+           WHERE c.company_id = $1 AND c.conversation_type = 'direct'
+           GROUP BY c.id
+           HAVING array_agg(cp.user_id ORDER BY cp.user_id) = $2::int[]
+           LIMIT 1`,
+          [input.companyId, sortedIds]
+        );
+
+        if (existing.rows.length > 0) {
+          const conversation = await this.fetchConversationById(Number(existing.rows[0].id), dbClient);
+          if (!conversation) {
+            throw new Error('Failed to load existing conversation.');
+          }
+          return { conversation, created: false };
+        }
+      }
+
+      const conversationResult = await dbClient.query(
+        `INSERT INTO conversations (company_id, conversation_type, title, created_by, last_message_at)
+         VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)
+         RETURNING id`,
+        [
+          input.companyId,
+          conversationType,
+          conversationType === 'group' ? input.title?.trim() || null : null,
+          input.createdBy,
+        ]
+      );
+
+      const conversationId = Number(conversationResult.rows[0].id);
+
+      const values: any[] = [conversationId];
+      const placeholders: string[] = [];
+      allParticipantIds.forEach((participantId, index) => {
+        values.push(participantId);
+        values.push(participantId === input.createdBy);
+        const offset = index * 2;
+        placeholders.push(`($1, $${offset + 2}, $${offset + 3})`);
+      });
+
+      await dbClient.query(
+        `INSERT INTO conversation_participants (conversation_id, user_id, is_admin)
+         VALUES ${placeholders.join(', ')}
+         ON CONFLICT (conversation_id, user_id) DO NOTHING`,
+        values
+      );
+
+      const conversation = await this.fetchConversationById(conversationId, dbClient);
+      if (!conversation) {
+        throw new Error('Conversation creation failed.');
+      }
+
+      return { conversation, created: true };
+    });
+  }
+
+  async getUserConversations(userId: number, companyId: number): Promise<ConversationDTO[]> {
+    const result = await this.db.query(
+      `SELECT
+         c.id,
+         c.company_id,
+         c.conversation_type,
+         c.title,
+         c.created_by,
+         c.last_message_at,
+         c.created_at,
+         c.updated_at,
+         participants.participant_list,
+         last_message.id AS last_message_id,
+         last_message.content AS last_message_content,
+         last_message.sender_id AS last_message_sender_id,
+         last_message.created_at AS last_message_created_at,
+         last_message.is_system AS last_message_is_system,
+         last_sender.username AS last_message_sender_username,
+         last_sender.email AS last_message_sender_email
+       FROM conversations c
+       JOIN conversation_participants membership ON membership.conversation_id = c.id AND membership.user_id = $1
+       LEFT JOIN LATERAL (
+         SELECT jsonb_agg(
+           jsonb_build_object(
+             'id', u.id,
+             'username', u.username,
+             'email', u.email,
+             'isAdmin', cp.is_admin
+           ) ORDER BY u.username
+         ) AS participant_list
+         FROM conversation_participants cp
+         LEFT JOIN users u ON u.id = cp.user_id
+         WHERE cp.conversation_id = c.id
+       ) AS participants ON TRUE
+       LEFT JOIN LATERAL (
+         SELECT m.id, m.content, m.sender_id, m.created_at, m.is_system
+         FROM messages m
+         WHERE m.conversation_id = c.id
+         ORDER BY m.created_at DESC
+         LIMIT 1
+       ) AS last_message ON TRUE
+       LEFT JOIN users last_sender ON last_sender.id = last_message.sender_id
+       WHERE c.company_id = $2
+       ORDER BY c.last_message_at DESC NULLS LAST, c.updated_at DESC, c.id DESC`,
+      [userId, companyId]
+    );
+
+    return result.rows.map((row) => this.mapConversation(row));
+  }
+
+  async appendMessage(conversationId: number, senderId: number, content: string): Promise<MessageDTO> {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      const error = new Error('Message content cannot be empty.');
+      (error as any).status = 400;
+      throw error;
+    }
+
+    return this.withTransaction(async (client) => {
+      await this.ensureParticipant(conversationId, senderId, client);
+
+      const insertResult = await client.query(
+        `INSERT INTO messages (conversation_id, sender_id, content)
+         VALUES ($1, $2, $3)
+         RETURNING id` ,
+        [conversationId, senderId, trimmed]
+      );
+
+      const messageId = Number(insertResult.rows[0].id);
+
+      await client.query(
+        `UPDATE conversations
+         SET last_message_at = CURRENT_TIMESTAMP,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [conversationId]
+      );
+
+      const messageResult = await client.query(
+        `SELECT m.id, m.conversation_id, m.sender_id, m.content, m.is_system, m.created_at, m.updated_at,
+                u.username, u.email
+         FROM messages m
+         LEFT JOIN users u ON u.id = m.sender_id
+         WHERE m.id = $1`,
+        [messageId]
+      );
+
+      if (messageResult.rows.length === 0) {
+        throw new Error('Failed to load message after creation.');
+      }
+
+      return this.mapMessage(messageResult.rows[0]);
+    });
+  }
+
+  async getConversationMessages(
+    conversationId: number,
+    userId: number,
+    options: { before?: string; limit?: number } = {}
+  ): Promise<MessageDTO[]> {
+    await this.ensureParticipant(conversationId, userId);
+
+    const limit = options.limit && options.limit > 0 ? Math.min(options.limit, 200) : 100;
+    const before = options.before ? new Date(options.before) : null;
+
+    const result = await this.db.query(
+      `SELECT m.id, m.conversation_id, m.sender_id, m.content, m.is_system, m.created_at, m.updated_at,
+              u.username, u.email
+       FROM messages m
+       LEFT JOIN users u ON u.id = m.sender_id
+       WHERE m.conversation_id = $1
+         AND ($2::timestamptz IS NULL OR m.created_at < $2::timestamptz)
+       ORDER BY m.created_at ASC
+       LIMIT $3`,
+      [conversationId, before, limit]
+    );
+
+    return result.rows.map((row) => this.mapMessage(row));
+  }
+}
+
+export const messagingService = new MessagingService(pool);

--- a/soft-sme-frontend/README.md
+++ b/soft-sme-frontend/README.md
@@ -1,3 +1,20 @@
+# Team Messaging Overview
+
+The Soft SME frontend now includes a dedicated **Messaging** workspace that surfaces both direct messages and group chats. The messaging panel keeps state in a shared React context, performs optimistic updates when you send messages, and polls the server every 10 seconds to stay in sync with new activity.
+
+## Starting a conversation
+1. Open the **Messaging** page from the sidebar.
+2. Use the **New** button to pick one teammate for a direct chat or multiple teammates for a group conversation.
+3. Provide a group name when more than one participant is selected, then click **Start**.
+4. Existing one-on-one conversations are reused automatically; you will jump straight into the history if a thread already exists.
+
+## Working in a thread
+- Messages you send appear instantly while the backend request completes. Any failures are highlighted so you can retry.
+- History refreshes automatically every 10 seconds for the active conversation, in addition to manual fetches when you switch threads.
+- Participant details and last-message timestamps are shown in the conversation list to help you triage discussions quickly.
+
+---
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/soft-sme-frontend/src/App.tsx
+++ b/soft-sme-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { HashRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { MessagingProvider } from './contexts/MessagingContext';
 import theme from './theme';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -19,7 +20,7 @@ import InventoryPage from './pages/InventoryPage';
 import SupplyPage from './pages/SupplyPage';
 import QuotePage from './pages/QuotePage';
 import QuoteEditorPage from './pages/QuoteEditorPage';
-
+import MessagingPage from './pages/MessagingPage';
 
 // import SalesOrderPage from './pages/SalesOrderPage';
 
@@ -196,6 +197,9 @@ const AppRoutes: React.FC = () => {
         
         {/* Email Templates */}
         <Route path="email-templates" element={<EmailTemplatesPage />} />
+
+        {/* Messaging */}
+        <Route path="messaging" element={<MessagingPage />} />
       </Route>
 
       {/* Catch all route */}
@@ -239,12 +243,14 @@ const App: React.FC = () => {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <AuthProvider>
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <Router>
-            <AppRoutes />
-          </Router>
-          <ToastContainer position="top-right" autoClose={3000} newestOnTop={false} closeOnClick pauseOnFocusLoss draggable pauseOnHover theme="colored" />
-        </LocalizationProvider>
+        <MessagingProvider>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <Router>
+              <AppRoutes />
+            </Router>
+            <ToastContainer position="top-right" autoClose={3000} newestOnTop={false} closeOnClick pauseOnFocusLoss draggable pauseOnHover theme="colored" />
+          </LocalizationProvider>
+        </MessagingProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/soft-sme-frontend/src/components/ConversationList.tsx
+++ b/soft-sme-frontend/src/components/ConversationList.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  List,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Add as AddIcon } from '@mui/icons-material';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { ConversationSummary } from '../contexts/MessagingContext';
+
+interface ConversationListProps {
+  conversations: ConversationSummary[];
+  activeConversationId: number | null;
+  onSelect: (conversationId: number) => void;
+  onStartConversation: () => void;
+  isLoading?: boolean;
+}
+
+const ConversationList: React.FC<ConversationListProps> = ({
+  conversations,
+  activeConversationId,
+  onSelect,
+  onStartConversation,
+  isLoading = false,
+}) => {
+  const [query, setQuery] = useState('');
+
+  const filteredConversations = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) {
+      return conversations;
+    }
+    return conversations.filter((conversation) => {
+      const name = conversation.displayName.toLowerCase();
+      const participants = conversation.participantNames.toLowerCase();
+      return name.includes(trimmed) || participants.includes(trimmed);
+    });
+  }, [conversations, query]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 2 }}>
+        <Typography variant="h6" component="h2">
+          Conversations
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={onStartConversation}
+          size="small"
+        >
+          New
+        </Button>
+      </Stack>
+
+      <TextField
+        fullWidth
+        size="small"
+        placeholder="Search conversations"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        sx={{ mb: 2 }}
+      />
+
+      <Divider />
+
+      <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%', py: 4 }}>
+            <CircularProgress size={32} />
+          </Box>
+        ) : filteredConversations.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 6, px: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              {query ? 'No conversations match your search.' : 'Start a new conversation to begin messaging.'}
+            </Typography>
+          </Box>
+        ) : (
+          <List disablePadding>
+            {filteredConversations.map((conversation) => {
+              const lastMessage = conversation.lastMessage?.content;
+              const lastTimestamp = conversation.lastMessageAt || conversation.updatedAt || conversation.createdAt;
+              const timeAgo = formatDistanceToNowStrict(new Date(lastTimestamp), { addSuffix: true });
+
+              return (
+                <React.Fragment key={conversation.id}>
+                  <ListItemButton
+                    selected={conversation.id === activeConversationId}
+                    alignItems="flex-start"
+                    onClick={() => onSelect(conversation.id)}
+                    sx={{
+                      py: 1.5,
+                      '&.Mui-selected': {
+                        backgroundColor: 'action.selected',
+                      },
+                      '& .MuiListItemText-secondary': {
+                        display: '-webkit-box',
+                        overflow: 'hidden',
+                        WebkitBoxOrient: 'vertical',
+                        WebkitLineClamp: 2,
+                      },
+                    }}
+                  >
+                    <ListItemAvatar>
+                      <Avatar>
+                        {conversation.displayName.charAt(0).toUpperCase()}
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText
+                      primary={
+                        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+                          <Typography variant="subtitle1" noWrap>
+                            {conversation.displayName}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                            {timeAgo}
+                          </Typography>
+                        </Stack>
+                      }
+                      secondary={lastMessage || 'No messages yet'}
+                    />
+                  </ListItemButton>
+                  <Divider component="li" />
+                </React.Fragment>
+              );
+            })}
+          </List>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ConversationList;

--- a/soft-sme-frontend/src/components/Layout.tsx
+++ b/soft-sme-frontend/src/components/Layout.tsx
@@ -37,6 +37,7 @@ import {
   Person as PersonIcon,
   Email as EmailIcon,
   Description as DescriptionIcon,
+  Chat as ChatIcon,
 } from '@mui/icons-material';
 import { useAuth } from '../contexts/AuthContext';
 import ChatBubble from './ChatBubble';
@@ -107,6 +108,9 @@ const Layout: React.FC = () => {
     { text: 'Leave Management', icon: <CalendarIcon />, path: '/leave-management' },
     { text: 'Mobile User Access', icon: <PeopleIcon />, path: '/mobile-user-access' },
 
+    { type: 'header', text: 'Communication' },
+    { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
+
     { type: 'header', text: 'Settings' },
     { text: 'Business Profile', icon: <BusinessIcon />, path: '/business-profile' },
     { text: 'Accounting', icon: <AttachMoneyIcon />, path: '/qbo-account-mapping' },
@@ -124,6 +128,8 @@ const Layout: React.FC = () => {
         { text: 'Time Tracking', icon: <TimelineIcon />, path: '/time-tracking' },
         { type: 'header', text: 'Human Resources' },
         { text: 'Leave Management', icon: <CalendarIcon />, path: '/leave-management' },
+        { type: 'header', text: 'Communication' },
+        { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
         { type: 'header', text: 'Sales' },
         { text: 'Sales Orders', icon: <ReceiptIcon />, path: '/open-sales-orders' },
       ];
@@ -143,6 +149,8 @@ const Layout: React.FC = () => {
         { type: 'header', text: 'Inventory' },
         { text: 'Stock', icon: <InventoryIcon />, path: '/inventory' },
         { text: 'Supply', icon: <InventoryIcon />, path: '/supply' },
+        { type: 'header', text: 'Communication' },
+        { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
         { type: 'header', text: 'Settings' },
         { text: 'Email Settings', icon: <EmailIcon />, path: '/email-settings' },
       ];

--- a/soft-sme-frontend/src/components/MessageThread.tsx
+++ b/soft-sme-frontend/src/components/MessageThread.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { format } from 'date-fns';
+import ChatInput from './ChatInput';
+import { ConversationSummary } from '../contexts/MessagingContext';
+import { MessagingMessage } from '../services/messagingService';
+
+interface MessageThreadProps {
+  conversation?: ConversationSummary;
+  messages: MessagingMessage[];
+  currentUserId: number | null;
+  isLoading: boolean;
+  isSending: boolean;
+  onSendMessage: (message: string) => Promise<void> | void;
+}
+
+const formatTimestamp = (timestamp: string): string => {
+  try {
+    return format(new Date(timestamp), 'MMM d, yyyy h:mm a');
+  } catch (error) {
+    return timestamp;
+  }
+};
+
+const MessageThread: React.FC<MessageThreadProps> = ({
+  conversation,
+  messages,
+  currentUserId,
+  isLoading,
+  isSending,
+  onSendMessage,
+}) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, [messages.length, isLoading]);
+
+  const participantSummary = useMemo(() => {
+    if (!conversation) {
+      return '';
+    }
+    return conversation.otherParticipants.length > 0
+      ? conversation.otherParticipants.map((participant) => participant.username || participant.email || 'Unknown user').join(', ')
+      : conversation.participantNames;
+  }, [conversation]);
+
+  if (!conversation) {
+    return (
+      <Paper sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="body1" color="text.secondary" align="center">
+          Select a conversation to view messages or start a new chat.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2">
+          {conversation.displayName}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {participantSummary}
+        </Typography>
+      </Box>
+
+      <Divider />
+
+      <Box ref={scrollRef} sx={{ flexGrow: 1, overflowY: 'auto', p: 2 }}>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+            <CircularProgress size={36} />
+          </Box>
+        ) : messages.length === 0 ? (
+          <Box sx={{ textAlign: 'center', color: 'text.secondary', mt: 6 }}>
+            <Typography variant="body2">No messages yet. Start the conversation below.</Typography>
+          </Box>
+        ) : (
+          <Stack spacing={2}>
+            {messages.map((message) => {
+              const isSelf = currentUserId !== null && message.senderId === currentUserId;
+              const align = isSelf ? 'flex-end' : 'flex-start';
+              const backgroundColor = message.error
+                ? 'error.light'
+                : isSelf
+                  ? 'primary.main'
+                  : 'grey.100';
+              const textColor = message.error ? 'error.dark' : isSelf ? 'common.white' : 'text.primary';
+
+              return (
+                <Box key={message.id} sx={{ display: 'flex', justifyContent: align }}>
+                  <Box sx={{ maxWidth: '75%', display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Paper
+                      elevation={isSelf ? 3 : 1}
+                      sx={{
+                        p: 1.5,
+                        bgcolor: backgroundColor,
+                        color: textColor,
+                        borderRadius: 2,
+                        border: message.error ? '1px solid' : 'none',
+                        borderColor: message.error ? 'error.main' : undefined,
+                      }}
+                    >
+                      <Stack spacing={0.5}>
+                        <Typography variant="caption" sx={{ opacity: isSelf ? 0.85 : 0.6 }}>
+                          {message.senderName || (isSelf ? 'You' : 'Unknown user')}
+                        </Typography>
+                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                          {message.content}
+                        </Typography>
+                        <Typography variant="caption" sx={{ opacity: isSelf ? 0.85 : 0.6, textAlign: 'right' }}>
+                          {formatTimestamp(message.createdAt)}
+                        </Typography>
+                      </Stack>
+                    </Paper>
+                    {message.pending && !message.error && (
+                      <Chip
+                        label="Sending..."
+                        size="small"
+                        color="default"
+                        sx={{ alignSelf: isSelf ? 'flex-end' : 'flex-start', mt: 0.5 }}
+                      />
+                    )}
+                    {message.error && (
+                      <Typography
+                        variant="caption"
+                        color="error"
+                        sx={{ alignSelf: isSelf ? 'flex-end' : 'flex-start' }}
+                      >
+                        Failed to send. Please try again.
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Stack>
+        )}
+      </Box>
+
+      <Divider />
+
+      <ChatInput onSendMessage={(value) => onSendMessage(value)} disabled={isSending} />
+    </Paper>
+  );
+};
+
+export default MessageThread;

--- a/soft-sme-frontend/src/contexts/MessagingContext.tsx
+++ b/soft-sme-frontend/src/contexts/MessagingContext.tsx
@@ -1,0 +1,344 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import messagingService, {
+  MessagingConversation,
+  MessagingMessage,
+  MessagingParticipant,
+} from '../services/messagingService';
+import { useAuth } from './AuthContext';
+
+export interface ConversationSummary extends MessagingConversation {
+  displayName: string;
+  participantNames: string;
+  otherParticipants: MessagingParticipant[];
+}
+
+interface MessagingContextValue {
+  conversations: ConversationSummary[];
+  isLoadingConversations: boolean;
+  activeConversationId: number | null;
+  selectConversation: (conversationId: number | null) => void;
+  messagesByConversation: Record<number, MessagingMessage[]>;
+  loadMessages: (conversationId: number, options?: { force?: boolean }) => Promise<void>;
+  isLoadingMessages: Record<number, boolean>;
+  sendMessage: (conversationId: number, content: string) => Promise<MessagingMessage>;
+  createConversation: (
+    payload: {
+      participantIds: number[];
+      title?: string;
+      type?: 'direct' | 'group';
+    }
+  ) => Promise<{ conversation: ConversationSummary; created: boolean }>;
+  refreshConversations: () => Promise<void>;
+}
+
+const MessagingContext = createContext<MessagingContextValue | undefined>(undefined);
+
+const buildDisplayName = (
+  conversation: MessagingConversation,
+  currentUserId: number | null
+): { displayName: string; otherParticipants: MessagingParticipant[]; participantNames: string } => {
+  const participants = conversation.participants ?? [];
+  const otherParticipants = currentUserId
+    ? participants.filter((participant) => participant.id !== currentUserId)
+    : participants;
+
+  const participantNames = participants
+    .map((participant) => participant.username || participant.email || 'Unknown user')
+    .join(', ');
+
+  if (conversation.conversationType === 'group') {
+    const title = conversation.title?.trim();
+    const fallback = `${participants.length} participants`;
+    return {
+      displayName: title || fallback,
+      otherParticipants,
+      participantNames,
+    };
+  }
+
+  if (otherParticipants.length === 1) {
+    const target = otherParticipants[0];
+    return {
+      displayName: target.username || target.email || 'Direct message',
+      otherParticipants,
+      participantNames,
+    };
+  }
+
+  const name = otherParticipants.length > 0
+    ? otherParticipants.map((participant) => participant.username || participant.email || 'Direct message').join(', ')
+    : conversation.title || 'Direct message';
+
+  return {
+    displayName: name,
+    otherParticipants,
+    participantNames,
+  };
+};
+
+const sortConversations = (items: ConversationSummary[]): ConversationSummary[] => {
+  return [...items].sort((a, b) => {
+    const aKey = a.lastMessageAt || a.updatedAt || a.createdAt;
+    const bKey = b.lastMessageAt || b.updatedAt || b.createdAt;
+    return new Date(bKey).getTime() - new Date(aKey).getTime();
+  });
+};
+
+export const MessagingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, user } = useAuth();
+  const currentUserId = user ? Number(user.id) : null;
+
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [isLoadingConversations, setIsLoadingConversations] = useState<boolean>(false);
+  const [messagesByConversation, setMessagesByConversation] = useState<Record<number, MessagingMessage[]>>({});
+  const [isLoadingMessages, setIsLoadingMessages] = useState<Record<number, boolean>>({});
+  const [activeConversationId, setActiveConversationId] = useState<number | null>(null);
+
+  const messagesCacheRef = useRef<Record<number, MessagingMessage[]>>({});
+  useEffect(() => {
+    messagesCacheRef.current = messagesByConversation;
+  }, [messagesByConversation]);
+
+  const decorateConversation = useCallback(
+    (conversation: MessagingConversation): ConversationSummary => {
+      const { displayName, otherParticipants, participantNames } = buildDisplayName(conversation, currentUserId);
+      return {
+        ...conversation,
+        displayName,
+        otherParticipants,
+        participantNames,
+      };
+    },
+    [currentUserId]
+  );
+
+  const refreshConversations = useCallback(async () => {
+    if (!isAuthenticated) {
+      return;
+    }
+    setIsLoadingConversations(true);
+    try {
+      const fetched = await messagingService.getConversations();
+      const decorated = sortConversations(fetched.map(decorateConversation));
+      setConversations(decorated);
+    } catch (error) {
+      console.error('Failed to load conversations', error);
+    } finally {
+      setIsLoadingConversations(false);
+    }
+  }, [decorateConversation, isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setConversations([]);
+      setMessagesByConversation({});
+      setIsLoadingConversations(false);
+      setIsLoadingMessages({});
+      setActiveConversationId(null);
+      return;
+    }
+    refreshConversations();
+  }, [isAuthenticated, refreshConversations]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+    const interval = setInterval(() => {
+      refreshConversations().catch(() => undefined);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [isAuthenticated, refreshConversations]);
+
+  useEffect(() => {
+    if (!isAuthenticated || conversations.length === 0) {
+      return;
+    }
+    if (!activeConversationId || !conversations.some((conversation) => conversation.id === activeConversationId)) {
+      setActiveConversationId(conversations[0].id);
+    }
+  }, [activeConversationId, conversations, isAuthenticated]);
+
+  const loadMessages = useCallback(
+    async (conversationId: number, options: { force?: boolean } = {}) => {
+      if (!isAuthenticated) {
+        return;
+      }
+      if (!options.force && messagesCacheRef.current[conversationId]) {
+        return;
+      }
+      setIsLoadingMessages((prev) => ({ ...prev, [conversationId]: true }));
+      try {
+        const fetched = await messagingService.getMessages(conversationId);
+        setMessagesByConversation((prev) => ({
+          ...prev,
+          [conversationId]: fetched.map((message) => ({ ...message, pending: false, error: false })),
+        }));
+      } catch (error) {
+        console.error('Failed to load messages', error);
+      } finally {
+        setIsLoadingMessages((prev) => ({ ...prev, [conversationId]: false }));
+      }
+    },
+    [isAuthenticated]
+  );
+
+  useEffect(() => {
+    if (!activeConversationId) {
+      return;
+    }
+    loadMessages(activeConversationId).catch(() => undefined);
+  }, [activeConversationId, loadMessages]);
+
+  useEffect(() => {
+    if (!activeConversationId || !isAuthenticated) {
+      return;
+    }
+    const interval = setInterval(() => {
+      loadMessages(activeConversationId, { force: true }).catch(() => undefined);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [activeConversationId, isAuthenticated, loadMessages]);
+
+  const selectConversation = useCallback(
+    (conversationId: number | null) => {
+      setActiveConversationId(conversationId);
+      if (conversationId) {
+        loadMessages(conversationId).catch(() => undefined);
+      }
+    },
+    [loadMessages]
+  );
+
+  const sendMessage = useCallback(
+    async (conversationId: number, content: string) => {
+      if (!isAuthenticated || !user) {
+        throw new Error('Not authenticated');
+      }
+      const trimmed = content.trim();
+      if (!trimmed) {
+        throw new Error('Message cannot be empty');
+      }
+
+      const optimisticId = `temp-${Date.now()}`;
+      const optimisticMessage: MessagingMessage = {
+        id: optimisticId,
+        conversationId,
+        senderId: currentUserId,
+        senderName: user.username || user.email || null,
+        content: trimmed,
+        isSystem: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        pending: true,
+      };
+
+      setMessagesByConversation((prev) => {
+        const existing = prev[conversationId] ?? [];
+        return {
+          ...prev,
+          [conversationId]: [...existing, optimisticMessage],
+        };
+      });
+
+      try {
+        const saved = await messagingService.postMessage(conversationId, trimmed);
+        setMessagesByConversation((prev) => {
+          const existing = prev[conversationId] ?? [];
+          return {
+            ...prev,
+            [conversationId]: existing.map((message) => (message.id === optimisticId ? saved : message)),
+          };
+        });
+        await refreshConversations();
+        return saved;
+      } catch (error) {
+        setMessagesByConversation((prev) => {
+          const existing = prev[conversationId] ?? [];
+          return {
+            ...prev,
+            [conversationId]: existing.map((message) =>
+              message.id === optimisticId ? { ...message, pending: false, error: true } : message
+            ),
+          };
+        });
+        throw error;
+      }
+    },
+    [currentUserId, isAuthenticated, refreshConversations, user]
+  );
+
+  const createConversation = useCallback(
+    async (
+      payload: {
+        participantIds: number[];
+        title?: string;
+        type?: 'direct' | 'group';
+      }
+    ) => {
+      if (!isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+      const result = await messagingService.createConversation(payload);
+      const decorated = decorateConversation(result.conversation);
+      setConversations((prev) => {
+        const filtered = prev.filter((conversation) => conversation.id !== decorated.id);
+        return sortConversations([decorated, ...filtered]);
+      });
+      setActiveConversationId(decorated.id);
+      if (result.created) {
+        setMessagesByConversation((prev) => ({
+          ...prev,
+          [decorated.id]: [],
+        }));
+      }
+      return { conversation: decorated, created: result.created };
+    },
+    [decorateConversation, isAuthenticated]
+  );
+
+  const value = useMemo<MessagingContextValue>(
+    () => ({
+      conversations,
+      isLoadingConversations,
+      activeConversationId,
+      selectConversation,
+      messagesByConversation,
+      loadMessages,
+      isLoadingMessages,
+      sendMessage,
+      createConversation,
+      refreshConversations,
+    }),
+    [
+      conversations,
+      isLoadingConversations,
+      activeConversationId,
+      selectConversation,
+      messagesByConversation,
+      loadMessages,
+      isLoadingMessages,
+      sendMessage,
+      createConversation,
+      refreshConversations,
+    ]
+  );
+
+  return <MessagingContext.Provider value={value}>{children}</MessagingContext.Provider>;
+};
+
+export const useMessaging = (): MessagingContextValue => {
+  const context = useContext(MessagingContext);
+  if (!context) {
+    throw new Error('useMessaging must be used within a MessagingProvider');
+  }
+  return context;
+};

--- a/soft-sme-frontend/src/pages/MessagingPage.tsx
+++ b/soft-sme-frontend/src/pages/MessagingPage.tsx
@@ -1,0 +1,275 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { toast } from 'react-toastify';
+import api from '../api/axios';
+import { useAuth } from '../contexts/AuthContext';
+import { useMessaging } from '../contexts/MessagingContext';
+import ConversationList from '../components/ConversationList';
+import MessageThread from '../components/MessageThread';
+
+interface EmployeeOption {
+  id: number;
+  username: string | null;
+  email: string | null;
+  access_role?: string;
+}
+
+const MessagingPage: React.FC = () => {
+  const { user } = useAuth();
+  const currentUserId = user ? Number(user.id) : null;
+
+  const {
+    conversations,
+    isLoadingConversations,
+    activeConversationId,
+    selectConversation,
+    messagesByConversation,
+    isLoadingMessages,
+    sendMessage,
+    createConversation,
+    loadMessages,
+  } = useMessaging();
+
+  const [employees, setEmployees] = useState<EmployeeOption[]>([]);
+  const [isLoadingEmployees, setIsLoadingEmployees] = useState<boolean>(false);
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+  const [selectedEmployees, setSelectedEmployees] = useState<EmployeeOption[]>([]);
+  const [groupTitle, setGroupTitle] = useState<string>('');
+  const [isCreatingConversation, setIsCreatingConversation] = useState<boolean>(false);
+  const [isSending, setIsSending] = useState<boolean>(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchEmployees = async () => {
+      try {
+        setIsLoadingEmployees(true);
+        const response = await api.get('/api/employees');
+        if (!isMounted) {
+          return;
+        }
+        const data = Array.isArray(response.data)
+          ? response.data
+          : [];
+        const normalized = data
+          .map((entry: any) => ({
+            id: Number(entry.id),
+            username: entry.username ?? null,
+            email: entry.email ?? null,
+            access_role: entry.access_role,
+          }))
+          .filter((employee: EmployeeOption) => employee.id !== currentUserId)
+          .sort((a: EmployeeOption, b: EmployeeOption) => {
+            const nameA = (a.username || a.email || '').toLowerCase();
+            const nameB = (b.username || b.email || '').toLowerCase();
+            return nameA.localeCompare(nameB);
+          });
+        setEmployees(normalized);
+      } catch (error) {
+        console.error('Failed to load employees', error);
+        toast.error('Unable to load team members.');
+      } finally {
+        if (isMounted) {
+          setIsLoadingEmployees(false);
+        }
+      }
+    };
+
+    fetchEmployees();
+    return () => {
+      isMounted = false;
+    };
+  }, [currentUserId]);
+
+  const activeConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === activeConversationId),
+    [activeConversationId, conversations]
+  );
+
+  const activeMessages = activeConversationId ? messagesByConversation[activeConversationId] ?? [] : [];
+  const messagesLoading = activeConversationId ? Boolean(isLoadingMessages[activeConversationId]) : false;
+
+  const handleStartConversation = () => {
+    setSelectedEmployees([]);
+    setGroupTitle('');
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    if (isCreatingConversation) {
+      return;
+    }
+    setDialogOpen(false);
+  };
+
+  const handleCreateConversation = async () => {
+    if (selectedEmployees.length === 0) {
+      toast.error('Select at least one teammate to start a conversation.');
+      return;
+    }
+
+    const participantIds = selectedEmployees.map((employee) => employee.id);
+    const type: 'direct' | 'group' = participantIds.length > 1 ? 'group' : 'direct';
+
+    if (type === 'group' && !groupTitle.trim()) {
+      toast.error('Enter a name for the group conversation.');
+      return;
+    }
+
+    try {
+      setIsCreatingConversation(true);
+      const result = await createConversation({
+        participantIds,
+        title: type === 'group' ? groupTitle.trim() : undefined,
+        type,
+      });
+
+      const { conversation, created } = result;
+      toast.success(created ? 'Conversation created successfully.' : 'Conversation already existed. Opening chat.');
+      setDialogOpen(false);
+      setSelectedEmployees([]);
+      setGroupTitle('');
+      await loadMessages(conversation.id, { force: true });
+    } catch (error) {
+      console.error('Failed to create conversation', error);
+      toast.error('Unable to start conversation. Please try again.');
+    } finally {
+      setIsCreatingConversation(false);
+    }
+  };
+
+  const handleSendMessage = async (value: string) => {
+    if (!activeConversationId) {
+      toast.error('Select a conversation before sending a message.');
+      return;
+    }
+    try {
+      setIsSending(true);
+      await sendMessage(activeConversationId, value);
+    } catch (error) {
+      console.error('Failed to send message', error);
+      toast.error('Failed to send message. Please try again.');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const autocompleteOptions = useMemo(() => employees, [employees]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: { xs: 2, md: 3 } }}>
+      <Stack spacing={1} sx={{ mb: 3 }}>
+        <Typography variant="h4" component="h1">
+          Messaging
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Collaborate with your team using direct messages and group chats.
+        </Typography>
+      </Stack>
+
+      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+        <Grid container spacing={2} sx={{ height: '100%' }}>
+          <Grid item xs={12} md={4} sx={{ height: { xs: 'auto', md: '100%' } }}>
+            <Paper sx={{ height: { xs: 'auto', md: '100%' }, p: 2, display: 'flex', flexDirection: 'column' }}>
+              <ConversationList
+                conversations={conversations}
+                activeConversationId={activeConversationId}
+                onSelect={selectConversation}
+                onStartConversation={handleStartConversation}
+                isLoading={isLoadingConversations}
+              />
+            </Paper>
+          </Grid>
+          <Grid item xs={12} md={8} sx={{ height: { xs: '60vh', md: '100%' } }}>
+            <MessageThread
+              conversation={activeConversation}
+              messages={activeMessages}
+              currentUserId={currentUserId}
+              isLoading={messagesLoading}
+              isSending={isSending}
+              onSendMessage={handleSendMessage}
+            />
+          </Grid>
+        </Grid>
+      </Box>
+
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} fullWidth maxWidth="sm">
+        <DialogTitle>Start a Conversation</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Autocomplete
+              multiple
+              options={autocompleteOptions}
+              value={selectedEmployees}
+              onChange={(_, value) => setSelectedEmployees(value)}
+              getOptionLabel={(option) => option.username || option.email || `User ${option.id}`}
+              renderOption={(props, option) => (
+                <li {...props} key={option.id}>
+                  <Stack spacing={0.25}>
+                    <Typography variant="body2">{option.username || option.email || `User ${option.id}`}</Typography>
+                    {option.email && (
+                      <Typography variant="caption" color="text.secondary">
+                        {option.email}
+                      </Typography>
+                    )}
+                  </Stack>
+                </li>
+              )}
+              filterSelectedOptions
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Participants"
+                  placeholder="Select team members"
+                  helperText="Choose one teammate for a direct chat or multiple for a group conversation."
+                />
+              )}
+              loading={isLoadingEmployees}
+              loadingText="Loading team members..."
+            />
+
+            {selectedEmployees.length > 1 && (
+              <TextField
+                label="Group name"
+                value={groupTitle}
+                onChange={(event) => setGroupTitle(event.target.value)}
+                placeholder="e.g., Operations Leads"
+                inputProps={{ maxLength: 80 }}
+              />
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog} disabled={isCreatingConversation}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleCreateConversation}
+            disabled={
+              isCreatingConversation ||
+              selectedEmployees.length === 0 ||
+              (selectedEmployees.length > 1 && !groupTitle.trim())
+            }
+          >
+            {isCreatingConversation ? 'Creating…' : 'Start'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default MessagingPage;

--- a/soft-sme-frontend/src/services/messagingService.ts
+++ b/soft-sme-frontend/src/services/messagingService.ts
@@ -1,0 +1,119 @@
+import api from '../api/axios';
+
+export interface MessagingParticipant {
+  id: number;
+  username: string | null;
+  email: string | null;
+  isAdmin: boolean;
+}
+
+export interface MessagingMessage {
+  id: number | string;
+  conversationId: number;
+  senderId: number | null;
+  senderName: string | null;
+  content: string;
+  isSystem: boolean;
+  createdAt: string;
+  updatedAt: string;
+  pending?: boolean;
+  error?: boolean;
+}
+
+export interface MessagingConversation {
+  id: number;
+  companyId: number;
+  conversationType: 'direct' | 'group';
+  title: string | null;
+  createdBy: number;
+  createdAt: string;
+  updatedAt: string;
+  lastMessageAt: string | null;
+  participants: MessagingParticipant[];
+  lastMessage: MessagingMessage | null;
+}
+
+interface CreateConversationPayload {
+  participantIds: number[];
+  title?: string;
+  type?: 'direct' | 'group';
+}
+
+const normalizeConversation = (conversation: any): MessagingConversation => ({
+  id: Number(conversation.id),
+  companyId: Number(conversation.companyId ?? conversation.company_id),
+  conversationType: conversation.conversationType ?? conversation.conversation_type,
+  title: conversation.title ?? null,
+  createdBy: Number(conversation.createdBy ?? conversation.created_by),
+  createdAt: conversation.createdAt ?? conversation.created_at,
+  updatedAt: conversation.updatedAt ?? conversation.updated_at,
+  lastMessageAt: conversation.lastMessageAt ?? conversation.last_message_at ?? null,
+  participants: Array.isArray(conversation.participants)
+    ? conversation.participants.map((participant: any) => ({
+        id: Number(participant.id),
+        username: participant.username ?? null,
+        email: participant.email ?? null,
+        isAdmin: Boolean(participant.isAdmin ?? participant.is_admin ?? false),
+      }))
+    : [],
+  lastMessage: conversation.lastMessage
+    ? {
+        id: Number(conversation.lastMessage.id),
+        conversationId: Number(conversation.lastMessage.conversationId ?? conversation.lastMessage.conversation_id ?? conversation.id),
+        senderId:
+          conversation.lastMessage.senderId !== undefined && conversation.lastMessage.senderId !== null
+            ? Number(conversation.lastMessage.senderId)
+            : null,
+        senderName: conversation.lastMessage.senderName ?? null,
+        content: conversation.lastMessage.content ?? '',
+        isSystem: Boolean(conversation.lastMessage.isSystem),
+        createdAt: conversation.lastMessage.createdAt ?? '',
+        updatedAt: conversation.lastMessage.updatedAt ?? conversation.lastMessage.createdAt ?? '',
+      }
+    : null,
+});
+
+const normalizeMessage = (message: any): MessagingMessage => ({
+  id: typeof message.id === 'number' || typeof message.id === 'string' ? message.id : Number(message.id),
+  conversationId: Number(message.conversationId ?? message.conversation_id),
+  senderId:
+    message.senderId !== undefined && message.senderId !== null
+      ? Number(message.senderId)
+      : message.sender_id !== undefined && message.sender_id !== null
+        ? Number(message.sender_id)
+        : null,
+  senderName: message.senderName ?? message.sender_name ?? message.username ?? null,
+  content: message.content ?? '',
+  isSystem: Boolean(message.isSystem ?? message.is_system ?? false),
+  createdAt: message.createdAt ?? message.created_at ?? new Date().toISOString(),
+  updatedAt: message.updatedAt ?? message.updated_at ?? message.createdAt ?? message.created_at ?? new Date().toISOString(),
+  pending: message.pending,
+  error: message.error,
+});
+
+export const messagingService = {
+  async createConversation(payload: CreateConversationPayload): Promise<{ conversation: MessagingConversation; created: boolean }> {
+    const response = await api.post('/api/messaging/conversations', payload);
+    const { conversation, created } = response.data;
+    return { conversation: normalizeConversation(conversation), created: Boolean(created) };
+  },
+
+  async getConversations(): Promise<MessagingConversation[]> {
+    const response = await api.get('/api/messaging/conversations');
+    const conversations = response.data?.conversations ?? [];
+    return conversations.map((conversation: any) => normalizeConversation(conversation));
+  },
+
+  async getMessages(conversationId: number, params: { before?: string; limit?: number } = {}): Promise<MessagingMessage[]> {
+    const response = await api.get(`/api/messaging/conversations/${conversationId}/messages`, { params });
+    const messages = response.data?.messages ?? [];
+    return messages.map((message: any) => normalizeMessage(message));
+  },
+
+  async postMessage(conversationId: number, content: string): Promise<MessagingMessage> {
+    const response = await api.post(`/api/messaging/conversations/${conversationId}/messages`, { content });
+    return normalizeMessage(response.data?.message ?? response.data);
+  },
+};
+
+export default messagingService;


### PR DESCRIPTION
## Summary
- default new conversations to have a current last_message_at and add automatic updated_at triggers for conversations and messages
- document the full SQL snippet to run the messaging migration directly from pgAdmin

## Testing
- CI=1 npm run build *(fails: Missing script "build" in workspace root)*

------
https://chatgpt.com/codex/tasks/task_e_68e413acd71083248cbc6432d323653b