### PR TITLE
Harden task chat access and data parsing

### DIFF
--- a/docs/tasks/task-chat.md
+++ b/docs/tasks/task-chat.md
@@ -1,0 +1,45 @@
+# Task Chat Messaging
+
+The task messaging system enables team members assigned to a task to collaborate through a real-time chat panel. This document summarizes the backend schema, API endpoints, and frontend usage patterns introduced with the chat feature.
+
+## Database schema
+
+The migration `20240901000000_create_task_messages_table.sql` introduces the following tables:
+
+- `tasks` – stores the core task metadata (title, status, priority, due dates, etc.).
+- `task_participants` – links users to tasks, including read tracking fields (`last_read_at` and `last_read_message_id`).
+- `task_messages` – stores chat messages for a task. Each message references both the parent task and the posting participant. JSONB columns support metadata and lightweight attachment payloads.
+
+Triggers ensure `tasks.updated_at` is touched whenever a message is inserted, enabling chronological sorting and change detection.
+
+## Backend endpoints
+
+Routes are exposed under `/api/tasks` (see `soft-sme-backend/src/routes/taskRoutes.ts`). All endpoints require authentication, scope access to the caller’s company, and verify that the caller is assigned to the task via `task_participants`.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/tasks/:taskId` | Returns the task record, participant roster, and the caller’s participant entry. |
+| `GET` | `/api/tasks/:taskId/messages` | Lists chat messages for the task. Supports incremental polling via the optional `after` query parameter. Response includes unread counts. |
+| `POST` | `/api/tasks/:taskId/messages` | Posts a new chat message. Sanitizes metadata and attachment payloads. Automatically marks the sender’s messages as read. |
+| `POST` | `/api/tasks/:taskId/messages/mark-read` | Updates read tracking for the caller and returns the latest unread count. |
+
+See `TaskMessageService` for data-access helpers (ensuring participants exist, returning mapped DTOs, and maintaining read state).
+
+## Frontend usage
+
+`TaskDetailPage` embeds the `TaskChat` component next to the task metadata. The chat component:
+
+- Polls `/api/tasks/:id/messages` on mount and every 15 seconds by default.
+- Displays unread badges and surfaces toast notifications for incoming messages from other participants.
+- Marks messages as read when the panel is active, keeping the unread indicator in sync with the backend.
+- Provides manual refresh controls and handles optimistic scrolling for a conversation-style experience.
+
+Shared types are available in `src/types/tasks.ts`, and API utilities live in `src/services/taskChatService.ts`.
+
+### Running the migration manually
+
+If you are applying the schema changes directly (for example, through pgAdmin), execute the SQL in `soft-sme-backend/migrations/20240901000000_create_task_messages_table.sql`. The script is idempotent and can be re-run safely; copy the full contents into a pgAdmin query window and run it against the application database.
+
+## Testing
+
+Automated coverage was added in `TaskMessageService.test.ts`, validating participant access checks, message mapping, message creation flows, and read-tracking behavior using a mocked query interface.

--- a/soft-sme-backend/migrations/20240901000000_create_task_messages_table.sql
+++ b/soft-sme-backend/migrations/20240901000000_create_task_messages_table.sql
@@ -1,0 +1,138 @@
+-- Task collaboration tables for task chat messaging
+-- This migration creates a lightweight task collaboration schema with
+-- participants and message tracking support.
+
+-- Ensure base tasks table exists for assignment tracking
+CREATE TABLE IF NOT EXISTS tasks (
+  id SERIAL PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  status VARCHAR(50) NOT NULL DEFAULT 'open',
+  priority VARCHAR(50) DEFAULT 'medium',
+  due_date TIMESTAMP WITH TIME ZONE,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  is_archived BOOLEAN DEFAULT FALSE,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_company_id ON tasks(company_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+
+-- Keep tasks.updated_at in sync on row updates
+CREATE OR REPLACE FUNCTION update_tasks_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_tasks_updated_at ON tasks;
+CREATE TRIGGER update_tasks_updated_at
+  BEFORE UPDATE ON tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION update_tasks_updated_at_column();
+
+-- Participant mapping between tasks and users
+CREATE TABLE IF NOT EXISTS task_participants (
+  id SERIAL PRIMARY KEY,
+  task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role VARCHAR(50) DEFAULT 'participant',
+  is_watcher BOOLEAN DEFAULT FALSE,
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  last_read_at TIMESTAMP WITH TIME ZONE,
+  last_read_message_id INTEGER,
+  notification_preference VARCHAR(50) DEFAULT 'app'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_participants_unique
+  ON task_participants(task_id, user_id);
+
+CREATE INDEX IF NOT EXISTS idx_task_participants_task_id ON task_participants(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_participants_user_id ON task_participants(user_id);
+
+-- Core message table referencing tasks and participants
+CREATE TABLE IF NOT EXISTS task_messages (
+  id SERIAL PRIMARY KEY,
+  task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  participant_id INTEGER NOT NULL REFERENCES task_participants(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  is_system BOOLEAN DEFAULT FALSE,
+  attachments JSONB DEFAULT '[]'::jsonb,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_messages_task_created ON task_messages(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_task_messages_participant ON task_messages(participant_id);
+
+-- Auto-update updated_at timestamp on message updates
+CREATE OR REPLACE FUNCTION update_task_messages_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_task_messages_updated_at ON task_messages;
+CREATE TRIGGER update_task_messages_updated_at
+  BEFORE UPDATE ON task_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION update_task_messages_updated_at_column();
+
+-- Track task touches when new messages are created
+CREATE OR REPLACE FUNCTION touch_task_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.task_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP TRIGGER IF EXISTS task_messages_touch_task ON task_messages;
+CREATE TRIGGER task_messages_touch_task
+  AFTER INSERT ON task_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION touch_task_updated_at();
+
+-- Ensure participants keep a valid last_read_message_id reference
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'task_participants' AND column_name = 'last_read_message_id') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints
+      WHERE table_name = 'task_participants'
+        AND constraint_name = 'task_participants_last_read_message_id_fkey'
+    ) THEN
+      ALTER TABLE task_participants
+        ADD CONSTRAINT task_participants_last_read_message_id_fkey
+        FOREIGN KEY (last_read_message_id)
+        REFERENCES task_messages(id)
+        ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;
+
+-- Helpful view for quick reporting (optional, only create if absent)
+CREATE OR REPLACE VIEW task_message_activity AS
+SELECT
+  tm.id AS message_id,
+  tm.task_id,
+  tm.participant_id,
+  tm.created_at,
+  tm.is_system,
+  tm.metadata,
+  tp.user_id,
+  tp.role,
+  t.company_id,
+  t.status
+FROM task_messages tm
+JOIN task_participants tp ON tp.id = tm.participant_id
+JOIN tasks t ON t.id = tm.task_id;

--- a/soft-sme-backend/src/app.ts
+++ b/soft-sme-backend/src/app.ts
@@ -27,6 +27,7 @@ import emailRouter from './routes/emailRoutes';
 import profileDocumentRouter from './routes/profileDocumentRoutes';
 
 import chatRouter from './routes/chatRoutes';
+import taskRouter from './routes/taskRoutes';
 
 // Load environment variables from backend-local .env
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
@@ -182,6 +183,9 @@ console.log('Registered global settings routes');
 
 app.use('/api/chat', authMiddleware, chatRouter);
 console.log('Registered chat routes');
+
+app.use('/api/tasks', taskRouter);
+console.log('Registered task routes');
 
 app.use('/api/ai-assistant', aiAssistantRouter);
 console.log('Registered AI assistant routes');

--- a/soft-sme-backend/src/routes/taskRoutes.ts
+++ b/soft-sme-backend/src/routes/taskRoutes.ts
@@ -1,0 +1,259 @@
+import express, { Request, Response } from 'express';
+import { pool } from '../db';
+import { authMiddleware } from '../middleware/authMiddleware';
+import {
+  TaskMessageService,
+  TaskAccessError,
+  TaskParticipant,
+} from '../services/TaskMessageService';
+
+const router = express.Router();
+const messageService = new TaskMessageService(pool);
+
+function parseId(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+router.use(authMiddleware);
+
+function ensureCompanyAccess(participant: TaskParticipant, companyId: number | null): boolean {
+  if (companyId == null) {
+    return false;
+  }
+  return participant.companyId == null || participant.companyId === companyId;
+}
+
+router.get('/:taskId/messages', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const userId = parseId(req.user?.id);
+    const companyId = parseId(req.user?.company_id);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const participant = await messageService.ensureParticipant(taskId, userId);
+    if (!ensureCompanyAccess(participant, companyId)) {
+      return res.status(403).json({ message: 'Task belongs to another company' });
+    }
+    const after = req.query.after ? parseId(req.query.after as string) ?? undefined : undefined;
+    const { messages, unreadCount } = await messageService.listMessages(taskId, participant, after);
+
+    res.json({
+      participant,
+      messages,
+      unreadCount,
+      lastSyncedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    if (error instanceof TaskAccessError && error.code === 'NOT_PARTICIPANT') {
+      return res.status(403).json({ message: 'You are not assigned to this task' });
+    }
+    console.error('Error fetching task messages:', error);
+    res.status(500).json({ message: 'Failed to load task messages' });
+  }
+});
+
+router.post('/:taskId/messages', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const userId = parseId(req.user?.id);
+    const companyId = parseId(req.user?.company_id);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const { content, metadata, attachments } = req.body;
+
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+      return res.status(400).json({ message: 'Message content is required' });
+    }
+
+    const participant = await messageService.ensureParticipant(taskId, userId);
+    if (!ensureCompanyAccess(participant, companyId)) {
+      return res.status(403).json({ message: 'Task belongs to another company' });
+    }
+
+    const sanitizedMetadata = metadata && typeof metadata === 'object' ? metadata : {};
+    const sanitizedAttachments = Array.isArray(attachments) ? attachments : [];
+
+    const message = await messageService.createMessage(
+      taskId,
+      participant,
+      content.trim(),
+      sanitizedMetadata,
+      sanitizedAttachments
+    );
+
+    const unreadCount = await messageService.getUnreadCount(taskId, participant.id, message.id);
+
+    res.status(201).json({
+      message,
+      participant: {
+        ...participant,
+        lastReadAt: message.createdAt,
+        lastReadMessageId: message.id,
+      },
+      unreadCount,
+    });
+  } catch (error) {
+    if (error instanceof TaskAccessError && error.code === 'NOT_PARTICIPANT') {
+      return res.status(403).json({ message: 'You are not assigned to this task' });
+    }
+    console.error('Error posting task message:', error);
+    res.status(500).json({ message: 'Failed to post message' });
+  }
+});
+
+router.post('/:taskId/messages/mark-read', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const userId = parseId(req.user?.id);
+    const companyId = parseId(req.user?.company_id);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const { lastMessageId } = req.body ?? {};
+    const lastId = parseId(lastMessageId);
+
+    const participant = await messageService.ensureParticipant(taskId, userId);
+    if (!ensureCompanyAccess(participant, companyId)) {
+      return res.status(403).json({ message: 'Task belongs to another company' });
+    }
+    const markResult = await messageService.markRead(participant, lastId ?? undefined);
+    const unreadCount = await messageService.getUnreadCount(
+      taskId,
+      participant.id,
+      markResult.lastReadMessageId
+    );
+
+    res.json({
+      participant: {
+        ...participant,
+        lastReadAt: markResult.lastReadAt,
+        lastReadMessageId: markResult.lastReadMessageId,
+      },
+      unreadCount,
+    });
+  } catch (error) {
+    if (error instanceof TaskAccessError && error.code === 'NOT_PARTICIPANT') {
+      return res.status(403).json({ message: 'You are not assigned to this task' });
+    }
+    console.error('Error marking messages as read:', error);
+    res.status(500).json({ message: 'Failed to update read status' });
+  }
+});
+
+router.get('/:taskId', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const userId = parseId(req.user?.id);
+    const companyId = parseId(req.user?.company_id);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const participant = await messageService.ensureParticipant(taskId, userId);
+    if (!ensureCompanyAccess(participant, companyId)) {
+      return res.status(403).json({ message: 'Task belongs to another company' });
+    }
+
+    const taskResult = await pool.query(
+      `SELECT id, title, description, status, priority, due_date, created_at, updated_at, created_by
+       FROM tasks
+       WHERE id = $1
+         AND company_id = $2`,
+      [taskId, companyId]
+    );
+
+    if (taskResult.rowCount === 0) {
+      return res.status(404).json({ message: 'Task not found' });
+    }
+
+    const participantsResult = await pool.query(
+      `SELECT
+         tp.id,
+         tp.user_id,
+         tp.role,
+         tp.is_watcher,
+         tp.joined_at,
+         tp.last_read_at,
+         tp.last_read_message_id,
+         u.name,
+         u.email
+       FROM task_participants tp
+       LEFT JOIN users u ON u.id = tp.user_id
+       WHERE tp.task_id = $1
+       ORDER BY tp.joined_at ASC`,
+      [taskId]
+    );
+
+    const taskRow = taskResult.rows[0];
+
+    res.json({
+      task: {
+        id: Number(taskRow.id),
+        title: taskRow.title,
+        description: taskRow.description,
+        status: taskRow.status,
+        priority: taskRow.priority,
+        dueDate: taskRow.due_date ? new Date(taskRow.due_date).toISOString() : null,
+        createdAt: taskRow.created_at ? new Date(taskRow.created_at).toISOString() : null,
+        updatedAt: taskRow.updated_at ? new Date(taskRow.updated_at).toISOString() : null,
+        createdBy: taskRow.created_by != null ? Number(taskRow.created_by) : null,
+      },
+      participant,
+      participants: participantsResult.rows.map((row) => ({
+        id: Number(row.id),
+        userId: row.user_id != null ? Number(row.user_id) : null,
+        role: row.role,
+        isWatcher: Boolean(row.is_watcher),
+        name: row.name ?? null,
+        email: row.email ?? null,
+        joinedAt: row.joined_at ? new Date(row.joined_at).toISOString() : null,
+        lastReadAt: row.last_read_at ? new Date(row.last_read_at).toISOString() : null,
+        lastReadMessageId: row.last_read_message_id != null ? Number(row.last_read_message_id) : null,
+      })),
+    });
+  } catch (error) {
+    if (error instanceof TaskAccessError && error.code === 'NOT_PARTICIPANT') {
+      return res.status(403).json({ message: 'You are not assigned to this task' });
+    }
+    console.error('Error fetching task details:', error);
+    res.status(500).json({ message: 'Failed to load task details' });
+  }
+});
+
+export default router;

--- a/soft-sme-backend/src/services/TaskMessageService.test.ts
+++ b/soft-sme-backend/src/services/TaskMessageService.test.ts
@@ -1,0 +1,167 @@
+import { QueryResult, QueryResultRow } from 'pg';
+import { TaskMessageService, TaskAccessError, TaskParticipant, Queryable } from './TaskMessageService';
+
+describe('TaskMessageService', () => {
+  class MockQueryable implements Queryable {
+    public queryFn = jest.fn<Promise<QueryResult<QueryResultRow>>, [string, (any[] | undefined)]>();
+
+    query<T extends QueryResultRow = QueryResultRow>(queryText: string, params?: any[]): Promise<QueryResult<T>> {
+      return this.queryFn(queryText, params) as Promise<QueryResult<T>>;
+    }
+  }
+
+  const participant: TaskParticipant = {
+    id: 21,
+    taskId: 42,
+    userId: 7,
+    role: 'participant',
+    isWatcher: false,
+    lastReadAt: null,
+    lastReadMessageId: null,
+    companyId: 3,
+    taskTitle: 'Demo Task',
+    taskStatus: 'open',
+  };
+
+  let mockDb: MockQueryable;
+  let service: TaskMessageService;
+
+  beforeEach(() => {
+    mockDb = new MockQueryable();
+    service = new TaskMessageService(mockDb);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps participant rows correctly', async () => {
+    const now = new Date('2024-08-31T12:00:00Z');
+    mockDb.queryFn.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          participant_id: participant.id,
+          task_id: participant.taskId,
+          user_id: participant.userId,
+          role: participant.role,
+          is_watcher: participant.isWatcher,
+          last_read_at: now,
+          last_read_message_id: 12,
+          company_id: participant.companyId,
+          task_title: participant.taskTitle,
+          task_status: participant.taskStatus,
+        },
+      ],
+    } as any);
+
+    const result = await service.ensureParticipant(participant.taskId, participant.userId);
+    expect(result).toEqual({
+      ...participant,
+      lastReadAt: now.toISOString(),
+      lastReadMessageId: 12,
+    });
+    expect(mockDb.queryFn).toHaveBeenCalledWith(expect.stringContaining('FROM task_participants'), [participant.taskId, participant.userId]);
+  });
+
+  it('throws TaskAccessError when user is not participant', async () => {
+    mockDb.queryFn.mockResolvedValueOnce({ rowCount: 0, rows: [] } as any);
+    await expect(service.ensureParticipant(participant.taskId, participant.userId)).rejects.toBeInstanceOf(TaskAccessError);
+  });
+
+  it('returns formatted messages and unread count', async () => {
+    const createdAt = new Date('2024-08-30T10:00:00Z');
+    mockDb.queryFn
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 5,
+            task_id: participant.taskId,
+            participant_id: participant.id,
+            content: 'Hello team',
+            is_system: false,
+            attachments: [],
+            metadata: { kind: 'note' },
+            created_at: createdAt,
+            updated_at: createdAt,
+            user_id: participant.userId,
+            sender_name: 'Demo User',
+            sender_email: 'demo@example.com',
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ unread: 2 }] } as any);
+
+    const result = await service.listMessages(participant.taskId, participant);
+    expect(result.unreadCount).toBe(2);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({
+      id: 5,
+      taskId: participant.taskId,
+      participantId: participant.id,
+      content: 'Hello team',
+      metadata: { kind: 'note' },
+      sender: {
+        participantId: participant.id,
+        userId: participant.userId,
+        name: 'Demo User',
+        email: 'demo@example.com',
+      },
+    });
+  });
+
+  it('creates a new message, touches task, and marks as read', async () => {
+    const createdAt = new Date('2024-08-31T12:34:00Z');
+    mockDb.queryFn
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 9,
+            task_id: participant.taskId,
+            participant_id: participant.id,
+            content: 'New update',
+            is_system: false,
+            attachments: [],
+            metadata: {},
+            created_at: createdAt,
+            updated_at: createdAt,
+            user_id: participant.userId,
+            sender_name: 'Demo User',
+            sender_email: 'demo@example.com',
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] } as any)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          { last_read_at: createdAt, last_read_message_id: 9 },
+        ],
+      } as any);
+
+    const message = await service.createMessage(participant.taskId, participant, 'New update');
+    expect(mockDb.queryFn).toHaveBeenCalledTimes(3);
+    expect(mockDb.queryFn.mock.calls[0][0]).toContain('WITH inserted AS');
+    expect(mockDb.queryFn.mock.calls[1][0]).toContain('UPDATE tasks');
+    expect(mockDb.queryFn.mock.calls[2][0]).toContain('UPDATE task_participants');
+    expect(message.content).toBe('New update');
+    expect(message.id).toBe(9);
+  });
+
+  it('markRead resolves latest message when id is omitted', async () => {
+    const latest = new Date('2024-08-31T13:00:00Z');
+    mockDb.queryFn
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_id: 11 }] } as any)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ last_read_at: latest, last_read_message_id: 11 }],
+      } as any);
+
+    const response = await service.markRead(participant);
+    expect(mockDb.queryFn).toHaveBeenNthCalledWith(1, expect.stringContaining('SELECT MAX'), [participant.taskId]);
+    expect(mockDb.queryFn).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE task_participants'), [11, participant.id]);
+    expect(response).toEqual({ lastReadAt: latest.toISOString(), lastReadMessageId: 11 });
+  });
+});

--- a/soft-sme-backend/src/services/TaskMessageService.ts
+++ b/soft-sme-backend/src/services/TaskMessageService.ts
@@ -1,0 +1,296 @@
+import { Pool, QueryResult, QueryResultRow } from 'pg';
+
+export interface Queryable {
+  query<T extends QueryResultRow = QueryResultRow>(queryText: string, params?: any[]): Promise<QueryResult<T>>;
+}
+
+export interface TaskParticipant {
+  id: number;
+  taskId: number;
+  userId: number;
+  role: string | null;
+  isWatcher: boolean;
+  lastReadAt: string | null;
+  lastReadMessageId: number | null;
+  companyId: number | null;
+  taskTitle?: string | null;
+  taskStatus?: string | null;
+}
+
+export interface TaskMessageSender {
+  participantId: number;
+  userId: number | null;
+  name: string | null;
+  email: string | null;
+}
+
+export interface TaskMessage {
+  id: number;
+  taskId: number;
+  participantId: number;
+  content: string;
+  isSystem: boolean;
+  attachments: any[];
+  metadata: Record<string, any>;
+  createdAt: string;
+  updatedAt: string;
+  sender: TaskMessageSender;
+}
+
+export class TaskAccessError extends Error {
+  constructor(message: string, public code: 'NOT_PARTICIPANT' | 'TASK_NOT_FOUND') {
+    super(message);
+    this.name = 'TaskAccessError';
+  }
+}
+
+export class TaskMessageService {
+  private db: Queryable;
+
+  constructor(pool: Queryable | Pool) {
+    this.db = pool;
+  }
+
+  async ensureParticipant(taskId: number, userId: number): Promise<TaskParticipant> {
+    const result = await this.db.query(
+      `SELECT
+        tp.id AS participant_id,
+        tp.task_id,
+        tp.user_id,
+        tp.role,
+        tp.is_watcher,
+        tp.last_read_at,
+        tp.last_read_message_id,
+        t.company_id,
+        t.title AS task_title,
+        t.status AS task_status
+      FROM task_participants tp
+      INNER JOIN tasks t ON t.id = tp.task_id
+      WHERE tp.task_id = $1
+        AND tp.user_id = $2
+        AND COALESCE(t.is_archived, FALSE) = FALSE`,
+      [taskId, userId]
+    );
+
+    if (result.rowCount === 0) {
+      throw new TaskAccessError('User is not a participant on this task', 'NOT_PARTICIPANT');
+    }
+
+    const row = result.rows[0];
+
+    return {
+      id: Number(row.participant_id),
+      taskId: Number(row.task_id),
+      userId: Number(row.user_id),
+      role: row.role ?? null,
+      isWatcher: Boolean(row.is_watcher),
+      lastReadAt: row.last_read_at ? new Date(row.last_read_at).toISOString() : null,
+      lastReadMessageId: row.last_read_message_id != null ? Number(row.last_read_message_id) : null,
+      companyId: row.company_id != null ? Number(row.company_id) : null,
+      taskTitle: row.task_title ?? null,
+      taskStatus: row.task_status ?? null,
+    };
+  }
+
+  async listMessages(
+    taskId: number,
+    participant: TaskParticipant,
+    afterMessageId?: number
+  ): Promise<{ messages: TaskMessage[]; unreadCount: number }> {
+    const params: any[] = [taskId];
+    let filter = '';
+
+    if (afterMessageId && Number.isFinite(afterMessageId)) {
+      params.push(afterMessageId);
+      filter = ' AND tm.id > $2';
+    }
+
+    const messageResult = await this.db.query(
+      `SELECT
+        tm.id,
+        tm.task_id,
+        tm.participant_id,
+        tm.content,
+        tm.is_system,
+        tm.attachments,
+        tm.metadata,
+        tm.created_at,
+        tm.updated_at,
+        tp.user_id,
+        u.name AS sender_name,
+        u.email AS sender_email
+      FROM task_messages tm
+      INNER JOIN task_participants tp ON tp.id = tm.participant_id
+      LEFT JOIN users u ON u.id = tp.user_id
+      WHERE tm.task_id = $1${filter}
+      ORDER BY tm.created_at ASC, tm.id ASC`,
+      params
+    );
+
+    const messages = messageResult.rows.map((row) => this.mapMessageRow(row));
+
+    const unreadResult = await this.db.query(
+      `SELECT COUNT(*)::int AS unread
+       FROM task_messages tm
+       WHERE tm.task_id = $1
+         AND tm.participant_id <> $2
+         AND tm.id > COALESCE($3, 0)`,
+      [taskId, participant.id, participant.lastReadMessageId]
+    );
+
+    const unreadCount = unreadResult.rows[0]?.unread ?? 0;
+
+    return { messages, unreadCount };
+  }
+
+  async createMessage(
+    taskId: number,
+    participant: TaskParticipant,
+    content: string,
+    metadata: Record<string, any> = {},
+    attachments: any[] = []
+  ): Promise<TaskMessage> {
+    const insertResult = await this.db.query(
+      `WITH inserted AS (
+        INSERT INTO task_messages (task_id, participant_id, content, metadata, attachments)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING *
+      )
+      SELECT
+        i.id,
+        i.task_id,
+        i.participant_id,
+        i.content,
+        i.is_system,
+        i.attachments,
+        i.metadata,
+        i.created_at,
+        i.updated_at,
+        tp.user_id,
+        u.name AS sender_name,
+        u.email AS sender_email
+      FROM inserted i
+      INNER JOIN task_participants tp ON tp.id = i.participant_id
+      LEFT JOIN users u ON u.id = tp.user_id`,
+      [taskId, participant.id, content, metadata, attachments]
+    );
+
+    const row = insertResult.rows[0];
+    const message = this.mapMessageRow(row);
+
+    await this.touchTask(taskId);
+    await this.markRead(participant, message.id);
+
+    return message;
+  }
+
+  async markRead(
+    participant: TaskParticipant,
+    lastMessageId?: number
+  ): Promise<{ lastReadAt: string | null; lastReadMessageId: number | null }> {
+    let targetMessageId: number | null = lastMessageId ?? null;
+
+    if (targetMessageId == null) {
+      const latestResult = await this.db.query(
+        'SELECT MAX(id) AS max_id FROM task_messages WHERE task_id = $1',
+        [participant.taskId]
+      );
+      const maxId = latestResult.rows[0]?.max_id;
+      targetMessageId = maxId != null ? Number(maxId) : null;
+    }
+
+    const updateResult = await this.db.query(
+      `UPDATE task_participants
+       SET last_read_at = CURRENT_TIMESTAMP,
+           last_read_message_id = CASE
+             WHEN $1 IS NULL THEN last_read_message_id
+             WHEN last_read_message_id IS NULL THEN $1
+             ELSE GREATEST(last_read_message_id, $1)
+           END
+       WHERE id = $2
+       RETURNING last_read_at, last_read_message_id`,
+      [targetMessageId, participant.id]
+    );
+
+    const updateRow = updateResult.rows[0];
+
+    return {
+      lastReadAt: updateRow?.last_read_at ? new Date(updateRow.last_read_at).toISOString() : null,
+      lastReadMessageId:
+        updateRow?.last_read_message_id != null ? Number(updateRow.last_read_message_id) : null,
+    };
+  }
+
+  async getUnreadCount(taskId: number, participantId: number, lastReadMessageId: number | null): Promise<number> {
+    const unreadResult = await this.db.query(
+      `SELECT COUNT(*)::int AS unread
+       FROM task_messages
+       WHERE task_id = $1
+         AND participant_id <> $2
+         AND id > COALESCE($3, 0)`,
+      [taskId, participantId, lastReadMessageId]
+    );
+
+    return unreadResult.rows[0]?.unread ?? 0;
+  }
+
+  async touchTask(taskId: number): Promise<void> {
+    await this.db.query('UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = $1', [taskId]);
+  }
+
+  private parseJsonArray(value: unknown): any[] {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (error) {
+        console.warn('Failed to parse JSON array value from task message record', error);
+        return [];
+      }
+    }
+    return [];
+  }
+
+  private parseJsonObject(value: unknown): Record<string, any> {
+    if (value && typeof value === 'object') {
+      return value as Record<string, any>;
+    }
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+        return parsed && typeof parsed === 'object' ? (parsed as Record<string, any>) : {};
+      } catch (error) {
+        console.warn('Failed to parse JSON object value from task message record', error);
+        return {};
+      }
+    }
+    return {};
+  }
+
+  private mapMessageRow(row: any): TaskMessage {
+    return {
+      id: Number(row.id),
+      taskId: Number(row.task_id),
+      participantId: Number(row.participant_id),
+      content: row.content,
+      isSystem: Boolean(row.is_system),
+      attachments: this.parseJsonArray(row.attachments),
+      metadata: this.parseJsonObject(row.metadata),
+      createdAt: row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : new Date(row.created_at).toISOString(),
+      updatedAt: row.updated_at instanceof Date
+        ? row.updated_at.toISOString()
+        : new Date(row.updated_at).toISOString(),
+      sender: {
+        participantId: Number(row.participant_id),
+        userId: row.user_id != null ? Number(row.user_id) : null,
+        name: row.sender_name ?? null,
+        email: row.sender_email ?? null,
+      },
+    };
+  }
+}

--- a/soft-sme-frontend/src/App.tsx
+++ b/soft-sme-frontend/src/App.tsx
@@ -46,6 +46,7 @@ import PartsToOrderPage from './pages/PartsToOrderPage';
 import MobileUserAccessPage from './pages/MobileUserAccessPage';
 import UserEmailSettingsPage from './pages/UserEmailSettingsPage';
 import EmailTemplatesPage from './pages/EmailTemplatesPage';
+import TaskDetailPage from './pages/TaskDetailPage';
 import { useEffect, useState } from 'react';
 import { syncPending, getPendingCount } from './services/offlineSync';
 import { ToastContainer } from 'react-toastify';
@@ -196,6 +197,9 @@ const AppRoutes: React.FC = () => {
         
         {/* Email Templates */}
         <Route path="email-templates" element={<EmailTemplatesPage />} />
+
+        {/* Tasks */}
+        <Route path="tasks/:id" element={<TaskDetailPage />} />
       </Route>
 
       {/* Catch all route */}

--- a/soft-sme-frontend/src/components/TaskChat.tsx
+++ b/soft-sme-frontend/src/components/TaskChat.tsx
@@ -1,0 +1,393 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Paper,
+  Box,
+  Typography,
+  Divider,
+  TextField,
+  Button,
+  IconButton,
+  CircularProgress,
+  Tooltip,
+  Badge,
+  Chip,
+} from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { toast } from 'react-toastify';
+
+dayjs.extend(relativeTime);
+import { taskChatService } from '../services/taskChatService';
+import { TaskMessage, TaskMessagesResponse, TaskParticipantSummary } from '../types/tasks';
+import { useAuth } from '../contexts/AuthContext';
+
+interface TaskChatProps {
+  taskId: number;
+  pollIntervalMs?: number;
+  onUnreadChange?: (count: number) => void;
+}
+
+interface MergeResult {
+  merged: TaskMessage[];
+  appended: TaskMessage[];
+}
+
+const sortMessages = (messages: TaskMessage[]): TaskMessage[] =>
+  [...messages].sort((a, b) => {
+    const aTime = new Date(a.createdAt).getTime();
+    const bTime = new Date(b.createdAt).getTime();
+    if (aTime === bTime) {
+      return a.id - b.id;
+    }
+    return aTime - bTime;
+  });
+
+const mergeMessages = (existing: TaskMessage[], incoming: TaskMessage[]): MergeResult => {
+  if (!incoming.length) {
+    return { merged: existing, appended: [] };
+  }
+  const map = new Map<number, TaskMessage>();
+  existing.forEach((msg) => map.set(msg.id, msg));
+  const appended: TaskMessage[] = [];
+  incoming.forEach((msg) => {
+    if (!map.has(msg.id)) {
+      appended.push(msg);
+    }
+    map.set(msg.id, msg);
+  });
+  const merged = sortMessages(Array.from(map.values()));
+  return { merged, appended };
+};
+
+const TaskChat: React.FC<TaskChatProps> = ({ taskId, pollIntervalMs = 15000, onUnreadChange }) => {
+  const { user } = useAuth();
+  const currentUserId = useMemo(() => {
+    if (!user?.id) return null;
+    const parsed = Number(user.id);
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [user?.id]);
+
+  const [messages, setMessages] = useState<TaskMessage[]>([]);
+  const [participant, setParticipant] = useState<TaskParticipantSummary | null>(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [posting, setPosting] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const chatBodyRef = useRef<HTMLDivElement | null>(null);
+  const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const initialLoadRef = useRef(true);
+  const lastMessageIdRef = useRef<number | null>(null);
+
+  const notifyUnreadChange = useCallback(
+    (count: number) => {
+      setUnreadCount(count);
+      onUnreadChange?.(count);
+    },
+    [onUnreadChange]
+  );
+
+  const scrollToBottom = useCallback((smooth = false) => {
+    const container = chatBodyRef.current;
+    if (!container) return;
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: smooth ? 'smooth' : 'auto',
+    });
+  }, []);
+
+  const shouldAutoScroll = useCallback(() => {
+    const container = chatBodyRef.current;
+    if (!container) return true;
+    const threshold = 120;
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    return distanceFromBottom <= threshold;
+  }, []);
+
+  const markMessagesAsRead = useCallback(
+    async (lastMessageId?: number | null) => {
+      try {
+        const response = await taskChatService.markMessagesRead(taskId, lastMessageId ?? undefined);
+        setParticipant(response.participant);
+        notifyUnreadChange(response.unreadCount);
+      } catch (err) {
+        console.warn('Failed to update read state for task chat', err);
+      }
+    },
+    [notifyUnreadChange, taskId]
+  );
+
+  const handleNewMessagesToast = useCallback(
+    (messages: TaskMessage[]) => {
+      if (!messages.length || initialLoadRef.current) {
+        return;
+      }
+      messages
+        .filter((msg) => msg.sender?.userId && currentUserId && msg.sender.userId !== currentUserId)
+        .forEach((msg) => {
+          const author = msg.sender?.name || 'Task teammate';
+          toast.info(`New message from ${author}`);
+        });
+    },
+    [currentUserId]
+  );
+
+  const applyMessages = useCallback(
+    (incoming: TaskMessage[], replace = false) => {
+      const autoScroll = shouldAutoScroll();
+      let appended: TaskMessage[] = [];
+      let latestId: number | null = lastMessageIdRef.current;
+
+      setMessages((current) => {
+        if (replace) {
+          const sorted = sortMessages(incoming);
+          appended = sorted;
+          latestId = sorted.length ? sorted[sorted.length - 1].id : null;
+          return sorted;
+        }
+        const { merged, appended: newMessages } = mergeMessages(current, incoming);
+        appended = newMessages;
+        latestId = merged.length ? merged[merged.length - 1].id : latestId;
+        return merged;
+      });
+
+      if (latestId != null && (lastMessageIdRef.current == null || latestId > lastMessageIdRef.current)) {
+        lastMessageIdRef.current = latestId;
+      }
+
+      if (appended.length) {
+        handleNewMessagesToast(appended);
+        if (autoScroll) {
+          setTimeout(() => scrollToBottom(true), 50);
+        }
+      } else if (autoScroll && replace) {
+        setTimeout(() => scrollToBottom(true), 50);
+      }
+
+      return { appended, latestId };
+    },
+    [handleNewMessagesToast, scrollToBottom, shouldAutoScroll]
+  );
+
+  const fetchMessages = useCallback(
+    async (options?: { initial?: boolean; forceFull?: boolean }) => {
+      try {
+        if (options?.initial) {
+          setLoading(true);
+        } else {
+          setError(null);
+        }
+
+        const after = options?.forceFull ? undefined : lastMessageIdRef.current ?? undefined;
+        const response: TaskMessagesResponse = await taskChatService.fetchMessages(taskId, after);
+        setParticipant(response.participant);
+        setLastSyncedAt(response.lastSyncedAt);
+
+        const { appended, latestId } = applyMessages(response.messages, !!options?.initial || options?.forceFull);
+        notifyUnreadChange(response.unreadCount);
+
+        if ((response.unreadCount > 0 || appended.length > 0) && latestId != null) {
+          await markMessagesAsRead(latestId);
+        }
+
+        if (options?.initial) {
+          initialLoadRef.current = false;
+        }
+      } catch (err: any) {
+        console.error('Failed to load task messages', err);
+        const message = err?.response?.data?.message || 'Unable to load task messages.';
+        setError(message);
+        if (options?.initial) {
+          toast.error(message);
+        }
+      } finally {
+        if (options?.initial) {
+          setLoading(false);
+        }
+      }
+    },
+    [applyMessages, markMessagesAsRead, notifyUnreadChange, taskId]
+  );
+
+  useEffect(() => {
+    initialLoadRef.current = true;
+    lastMessageIdRef.current = null;
+    setMessages([]);
+    setParticipant(null);
+    notifyUnreadChange(0);
+    fetchMessages({ initial: true, forceFull: true }).catch(() => undefined);
+
+    return () => {
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [fetchMessages, notifyUnreadChange, taskId]);
+
+  useEffect(() => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+    }
+
+    if (pollIntervalMs <= 0) {
+      return;
+    }
+
+    pollTimerRef.current = setInterval(() => {
+      fetchMessages({ forceFull: false }).catch(() => undefined);
+    }, pollIntervalMs);
+
+    return () => {
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [fetchMessages, pollIntervalMs]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      if (!draft.trim()) {
+        return;
+      }
+      try {
+        setPosting(true);
+        const response = await taskChatService.postMessage(taskId, { content: draft.trim() });
+        setParticipant(response.participant);
+        notifyUnreadChange(response.unreadCount);
+        applyMessages([response.message]);
+        lastMessageIdRef.current = response.message.id;
+        setDraft('');
+        setTimeout(() => scrollToBottom(true), 50);
+      } catch (err: any) {
+        console.error('Failed to send message', err);
+        toast.error(err?.response?.data?.message || 'Failed to send message');
+      } finally {
+        setPosting(false);
+      }
+    },
+    [applyMessages, draft, notifyUnreadChange, scrollToBottom, taskId]
+  );
+
+  const handleManualRefresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      await fetchMessages({ forceFull: true });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [fetchMessages]);
+
+  const lastSyncLabel = useMemo(() => {
+    if (!lastSyncedAt) {
+      return 'Not synced yet';
+    }
+    return `Updated ${dayjs(lastSyncedAt).fromNow()}`;
+  }, [lastSyncedAt]);
+
+  const renderMessage = (message: TaskMessage) => {
+    const isOwn = currentUserId != null && message.sender?.userId === currentUserId;
+    const author = isOwn ? 'You' : message.sender?.name || 'Team member';
+    const timestamp = dayjs(message.createdAt).format('MMM D, YYYY h:mm A');
+
+    return (
+      <Box
+        key={message.id}
+        display="flex"
+        flexDirection="column"
+        alignItems={isOwn ? 'flex-end' : 'flex-start'}
+        mb={2}
+      >
+        <Box
+          sx={{
+            maxWidth: '80%',
+            bgcolor: isOwn ? 'primary.main' : 'grey.100',
+            color: isOwn ? 'primary.contrastText' : 'text.primary',
+            px: 2,
+            py: 1,
+            borderRadius: 2,
+            boxShadow: 1,
+          }}
+        >
+          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+            {message.content}
+          </Typography>
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+          {author} · {timestamp}
+        </Typography>
+      </Box>
+    );
+  };
+
+  return (
+    <Paper elevation={2} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box display="flex" alignItems="center" justifyContent="space-between" px={2} py={1.5}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="h6">Task chat</Typography>
+          <Badge color="secondary" badgeContent={unreadCount} invisible={unreadCount === 0}>
+            <Chip label="Unread" size="small" variant={unreadCount ? 'filled' : 'outlined'} />
+          </Badge>
+        </Box>
+        <Box display="flex" alignItems="center" gap={1}>
+          {lastSyncedAt && <Typography variant="caption" color="text.secondary">{lastSyncLabel}</Typography>}
+          <Tooltip title="Refresh conversation">
+            <span>
+              <IconButton onClick={handleManualRefresh} disabled={refreshing || loading} size="small">
+                {refreshing ? <CircularProgress size={18} /> : <RefreshIcon fontSize="small" />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Box>
+      </Box>
+      <Divider />
+      <Box ref={chatBodyRef} flex={1} overflow="auto" px={2} py={2}>
+        {loading ? (
+          <Box display="flex" alignItems="center" justifyContent="center" height="100%">
+            <CircularProgress size={32} />
+          </Box>
+        ) : error ? (
+          <Typography color="error" variant="body2">
+            {error}
+          </Typography>
+        ) : messages.length === 0 ? (
+          <Box textAlign="center" color="text.secondary">
+            <Typography variant="body2">No messages yet. Start the conversation below.</Typography>
+          </Box>
+        ) : (
+          messages.map((message) => renderMessage(message))
+        )}
+      </Box>
+      <Divider />
+      <Box component="form" onSubmit={handleSubmit} display="flex" gap={1} px={2} py={1.5}>
+        <TextField
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Write a message"
+          fullWidth
+          minRows={2}
+          maxRows={4}
+          multiline
+          disabled={posting}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          endIcon={posting ? <CircularProgress color="inherit" size={18} /> : <SendIcon />}
+          disabled={posting || draft.trim().length === 0}
+        >
+          Send
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default TaskChat;

--- a/soft-sme-frontend/src/pages/TaskDetailPage.tsx
+++ b/soft-sme-frontend/src/pages/TaskDetailPage.tsx
@@ -1,0 +1,173 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Paper,
+  Chip,
+  Grid,
+  CircularProgress,
+  Avatar,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { toast } from 'react-toastify';
+import TaskChat from '../components/TaskChat';
+import { taskChatService } from '../services/taskChatService';
+import { TaskDetailResponse } from '../types/tasks';
+
+dayjs.extend(relativeTime);
+
+const TaskDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const taskId = useMemo(() => {
+    if (!id) return NaN;
+    const parsed = Number(id);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }, [id]);
+
+  const [detail, setDetail] = useState<TaskDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const loadTask = useCallback(async () => {
+    if (!Number.isFinite(taskId)) {
+      setError('Invalid task identifier');
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await taskChatService.getTaskDetail(taskId);
+      setDetail(response);
+    } catch (err: any) {
+      console.error('Failed to load task details', err);
+      const message = err?.response?.data?.message || 'Unable to load task details.';
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    loadTask();
+  }, [loadTask]);
+
+  const handleUnreadChange = useCallback((count: number) => {
+    setUnreadCount(count);
+  }, []);
+
+  if (!Number.isFinite(taskId)) {
+    return (
+      <Box p={3}>
+        <Typography color="error">Invalid task identifier.</Typography>
+      </Box>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Box p={3} display="flex" alignItems="center" justifyContent="center" minHeight="40vh">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={3}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!detail) {
+    return null;
+  }
+
+  const { task, participants } = detail;
+
+  return (
+    <Box p={3} display="flex" flexDirection="column" gap={3}>
+      <Box display="flex" flexDirection={{ xs: 'column', md: 'row' }} gap={2} justifyContent="space-between">
+        <Box>
+          <Typography variant="h4" gutterBottom>
+            {task.title}
+          </Typography>
+          <Box display="flex" flexWrap="wrap" gap={1} alignItems="center">
+            <Chip label={task.status} color={task.status === 'completed' ? 'success' : 'default'} />
+            <Chip label={`Priority: ${task.priority ?? 'N/A'}`} variant="outlined" />
+            {task.dueDate && (
+              <Chip label={`Due ${dayjs(task.dueDate).format('MMM D, YYYY')}`} color="warning" />
+            )}
+            {unreadCount > 0 && <Chip label={`${unreadCount} unread`} color="secondary" />}
+          </Box>
+        </Box>
+        <Box textAlign={{ xs: 'left', md: 'right' }} color="text.secondary">
+          {task.updatedAt && (
+            <Typography variant="body2">Updated {dayjs(task.updatedAt).format('MMM D, YYYY h:mm A')}</Typography>
+          )}
+          {task.createdAt && (
+            <Typography variant="body2">Created {dayjs(task.createdAt).format('MMM D, YYYY h:mm A')}</Typography>
+          )}
+        </Box>
+      </Box>
+
+      {task.description && (
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle1" gutterBottom>
+            Description
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-wrap' }}>
+            {task.description}
+          </Typography>
+        </Paper>
+      )}
+
+      <Grid container spacing={3} alignItems="stretch">
+        <Grid item xs={12} md={4}>
+          <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
+            <Typography variant="subtitle1" gutterBottom>
+              Participants
+            </Typography>
+            {participants.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                No participants assigned.
+              </Typography>
+            ) : (
+              <Box display="flex" flexDirection="column" gap={1.5}>
+                {participants.map((participant) => {
+                  const initials = (participant.name || participant.email || 'T')[0]?.toUpperCase();
+                  return (
+                    <Box key={participant.id} display="flex" alignItems="center" gap={1.5}>
+                      <Avatar sx={{ bgcolor: 'primary.main' }}>{initials}</Avatar>
+                      <Box flex={1}>
+                        <Typography variant="body2">{participant.name || 'Unnamed user'}</Typography>
+                        <Typography variant="caption" color="text.secondary" display="block">
+                          {participant.email || 'No email'} · {participant.role || 'Participant'}
+                        </Typography>
+                        {participant.lastReadAt && (
+                          <Typography variant="caption" color="text.secondary" display="block">
+                            Read {dayjs(participant.lastReadAt).fromNow()}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  );
+                })}
+              </Box>
+            )}
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={8}>
+          <TaskChat taskId={taskId} onUnreadChange={handleUnreadChange} />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default TaskDetailPage;

--- a/soft-sme-frontend/src/services/taskChatService.ts
+++ b/soft-sme-frontend/src/services/taskChatService.ts
@@ -1,0 +1,43 @@
+import api from '../api/axios';
+import {
+  TaskMessagesResponse,
+  CreateTaskMessagePayload,
+  TaskDetailResponse,
+} from '../types/tasks';
+
+interface CreateMessageResponse {
+  message: TaskMessagesResponse['messages'][number];
+  participant: TaskMessagesResponse['participant'];
+  unreadCount: number;
+}
+
+interface MarkReadResponse {
+  participant: TaskMessagesResponse['participant'];
+  unreadCount: number;
+}
+
+export const taskChatService = {
+  async fetchMessages(taskId: number, after?: number): Promise<TaskMessagesResponse> {
+    const response = await api.get(`/api/tasks/${taskId}/messages`, {
+      params: after ? { after } : undefined,
+    });
+    return response.data as TaskMessagesResponse;
+  },
+
+  async postMessage(taskId: number, payload: CreateTaskMessagePayload): Promise<CreateMessageResponse> {
+    const response = await api.post(`/api/tasks/${taskId}/messages`, payload);
+    return response.data as CreateMessageResponse;
+  },
+
+  async markMessagesRead(taskId: number, lastMessageId?: number): Promise<MarkReadResponse> {
+    const response = await api.post(`/api/tasks/${taskId}/messages/mark-read`, {
+      lastMessageId,
+    });
+    return response.data as MarkReadResponse;
+  },
+
+  async getTaskDetail(taskId: number): Promise<TaskDetailResponse> {
+    const response = await api.get(`/api/tasks/${taskId}`);
+    return response.data as TaskDetailResponse;
+  },
+};

--- a/soft-sme-frontend/src/types/tasks.ts
+++ b/soft-sme-frontend/src/types/tasks.ts
@@ -1,0 +1,62 @@
+export interface TaskSummary {
+  id: number;
+  title: string;
+  status: string;
+  priority: string;
+  description?: string | null;
+  dueDate?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  createdBy?: number | null;
+}
+
+export interface TaskParticipantSummary {
+  id: number;
+  userId: number | null;
+  role: string | null;
+  isWatcher: boolean;
+  name: string | null;
+  email: string | null;
+  joinedAt: string | null;
+  lastReadAt: string | null;
+  lastReadMessageId: number | null;
+}
+
+export interface TaskMessageSender {
+  participantId: number;
+  userId: number | null;
+  name: string | null;
+  email: string | null;
+}
+
+export interface TaskMessage {
+  id: number;
+  taskId: number;
+  participantId: number;
+  content: string;
+  isSystem: boolean;
+  attachments: unknown[];
+  metadata: Record<string, any>;
+  createdAt: string;
+  updatedAt: string;
+  sender: TaskMessageSender;
+}
+
+export interface TaskMessagesResponse {
+  participant: TaskParticipantSummary;
+  messages: TaskMessage[];
+  unreadCount: number;
+  lastSyncedAt: string;
+}
+
+export interface CreateTaskMessagePayload {
+  content: string;
+  metadata?: Record<string, any>;
+  attachments?: unknown[];
+}
+
+export interface TaskDetailResponse {
+  task: TaskSummary;
+  participant: TaskParticipantSummary;
+  participants: TaskParticipantSummary[];
+}


### PR DESCRIPTION
## Summary
- add a migration that introduces task, participant, and task_messages tables with timestamps and triggers
- implement TaskMessageService, API routes, and tests to manage task-specific chat interactions and read tracking
- build TaskChat component, supporting service layer, and a task detail page to surface the threaded conversation UI; document the system
- enforce company-scoped access for task chat endpoints, normalize JSON payload handling, and describe how to run the migration manually in docs

## Testing
- `cd soft-sme-backend && npm test -- --runInBand --runTestsByPath src/services/TaskMessageService.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68e413af5ef48324831f504abd5254ae