### PR TITLE
Fix duplicate task router registration

### DIFF
--- a/soft-sme-backend/src/app.ts
+++ b/soft-sme-backend/src/app.ts
@@ -29,7 +29,6 @@ import taskRouter from './routes/taskRoutes';
 import messagingRouter from './routes/messagingRoutes';
 
 import chatRouter from './routes/chatRoutes';
-import taskRouter from './routes/taskRoutes';
 
 // Load environment variables from backend-local .env
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
@@ -196,16 +195,13 @@ console.log('Registered global settings routes');
 app.use('/api/chat', authMiddleware, chatRouter);
 console.log('Registered chat routes');
 
-app.use('/api/tasks', taskRouter);
-console.log('Registered task routes');
-
 app.use('/api/ai-assistant', aiAssistantRouter);
 console.log('Registered AI assistant routes');
 
 app.use('/api/email', authMiddleware, emailRouter);
 console.log('Registered email routes');
 
-app.use('/api/tasks', authMiddleware, taskRouter);
+app.use('/api/tasks', taskRouter);
 console.log('Registered task routes');
 
 // Health check endpoint


### PR DESCRIPTION
## Summary
- remove the duplicate task router import in the Express app configuration
- keep a single tasks route registration to prevent redundant middleware setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e450e7288883248f796dde9a169855