### PR TITLE
Add authenticated task management endpoints and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@mui/x-data-grid": "^8.5.0",
     "@mui/x-date-pickers": "^8.5.0",
+    "@tanstack/react-query": "^5.62.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "jwt-decode": "^4.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model User {
   password      String?
   accounts      Account[]
   sessions      Session[]
+  tasks         Task[]
 }
 
 model VerificationToken {
@@ -54,4 +55,32 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+}
+
+model Task {
+  id          String       @id @default(cuid())
+  title       String
+  description String?
+  status      TaskStatus   @default(TODO)
+  priority    TaskPriority @default(MEDIUM)
+  dueDate     DateTime?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  ownerId String
+
+  @@index([ownerId, status])
+}
+
+enum TaskStatus {
+  TODO
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum TaskPriority {
+  LOW
+  MEDIUM
+  HIGH
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,209 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../auth/[...nextauth]/route";
+import { prisma } from "@/lib/prisma";
+import { TaskPriority, TaskStatus } from "@prisma/client";
+
+const statusValues = new Set<string>(Object.values(TaskStatus));
+const priorityValues = new Set<string>(Object.values(TaskPriority));
+
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function notFound() {
+  return NextResponse.json({ error: "Task not found" }, { status: 404 });
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+async function getCurrentUserId() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { id: true },
+  });
+
+  return user?.id ?? null;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return unauthorized();
+  }
+
+  try {
+    const task = await prisma.task.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!task || task.ownerId !== userId) {
+      return notFound();
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error("Failed to load task", error);
+    return NextResponse.json(
+      { error: "Unable to load task" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return unauthorized();
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!body || typeof body !== "object") {
+    return badRequest("Request body is required");
+  }
+
+  const { title, description, status, priority, dueDate } = body as {
+    title?: unknown;
+    description?: unknown;
+    status?: unknown;
+    priority?: unknown;
+    dueDate?: unknown;
+  };
+
+  const updateData: Record<string, unknown> = {};
+
+  if (title !== undefined) {
+    if (typeof title !== "string" || title.trim().length === 0) {
+      return badRequest("Title must be a non-empty string");
+    }
+
+    updateData.title = title.trim();
+  }
+
+  if (description !== undefined) {
+    if (description === null || description === "") {
+      updateData.description = null;
+    } else if (typeof description === "string") {
+      updateData.description = description.trim();
+    } else {
+      return badRequest("Description must be a string");
+    }
+  }
+
+  if (status !== undefined) {
+    if (typeof status !== "string" || !statusValues.has(status)) {
+      return badRequest("Invalid task status provided");
+    }
+
+    updateData.status = status;
+  }
+
+  if (priority !== undefined) {
+    if (typeof priority !== "string" || !priorityValues.has(priority)) {
+      return badRequest("Invalid task priority provided");
+    }
+
+    updateData.priority = priority;
+  }
+
+  if (dueDate !== undefined) {
+    if (dueDate === null || dueDate === "") {
+      updateData.dueDate = null;
+    } else if (typeof dueDate === "string") {
+      const due = new Date(dueDate);
+
+      if (Number.isNaN(due.getTime())) {
+        return badRequest("Invalid due date provided");
+      }
+
+      updateData.dueDate = due;
+    } else {
+      return badRequest("Due date must be a string in ISO format");
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return badRequest("No updates provided");
+  }
+
+  try {
+    const existingTask = await prisma.task.findUnique({
+      where: { id: params.id },
+      select: { ownerId: true },
+    });
+
+    if (!existingTask || existingTask.ownerId !== userId) {
+      return notFound();
+    }
+
+    const updatedTask = await prisma.task.update({
+      where: { id: params.id },
+      data: updateData,
+    });
+
+    return NextResponse.json(updatedTask);
+  } catch (error) {
+    console.error("Failed to update task", error);
+    return NextResponse.json(
+      { error: "Unable to update task" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const userId = await getCurrentUserId();
+
+  if (!userId) {
+    return unauthorized();
+  }
+
+  try {
+    const existingTask = await prisma.task.findUnique({
+      where: { id: params.id },
+      select: { ownerId: true },
+    });
+
+    if (!existingTask || existingTask.ownerId !== userId) {
+      return notFound();
+    }
+
+    await prisma.task.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete task", error);
+    return NextResponse.json(
+      { error: "Unable to delete task" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+import { prisma } from "@/lib/prisma";
+import { TaskPriority, TaskStatus } from "@prisma/client";
+
+const statusValues = new Set<string>(Object.values(TaskStatus));
+const priorityValues = new Set<string>(Object.values(TaskPriority));
+
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return unauthorized();
+  }
+
+  try {
+    const tasks = await prisma.task.findMany({
+      where: {
+        owner: {
+          email: session.user.email,
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    return NextResponse.json(tasks);
+  } catch (error) {
+    console.error("Failed to load tasks", error);
+    return NextResponse.json(
+      { error: "Unable to load tasks" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return unauthorized();
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!body || typeof body !== "object") {
+    return badRequest("Request body is required");
+  }
+
+  const { title, description, status, priority, dueDate } = body as {
+    title?: unknown;
+    description?: unknown;
+    status?: unknown;
+    priority?: unknown;
+    dueDate?: unknown;
+  };
+
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return badRequest("A task title is required");
+  }
+
+  const parsedDescription =
+    typeof description === "string" && description.trim().length > 0
+      ? description.trim()
+      : null;
+
+  const resolvedStatus =
+    status === undefined
+      ? TaskStatus.TODO
+      : typeof status === "string" && statusValues.has(status)
+        ? (status as TaskStatus)
+        : null;
+
+  if (!resolvedStatus) {
+    return badRequest("Invalid task status provided");
+  }
+
+  const resolvedPriority =
+    priority === undefined
+      ? TaskPriority.MEDIUM
+      : typeof priority === "string" && priorityValues.has(priority)
+        ? (priority as TaskPriority)
+        : null;
+
+  if (!resolvedPriority) {
+    return badRequest("Invalid task priority provided");
+  }
+
+  let parsedDueDate: Date | null = null;
+
+  if (dueDate !== undefined && dueDate !== null && dueDate !== "") {
+    if (typeof dueDate !== "string") {
+      return badRequest("Due date must be a string in ISO format");
+    }
+
+    const due = new Date(dueDate);
+
+    if (Number.isNaN(due.getTime())) {
+      return badRequest("Invalid due date provided");
+    }
+
+    parsedDueDate = due;
+  }
+
+  try {
+    const owner = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true },
+    });
+
+    if (!owner) {
+      return unauthorized();
+    }
+
+    const task = await prisma.task.create({
+      data: {
+        title: title.trim(),
+        description: parsedDescription,
+        status: resolvedStatus,
+        priority: resolvedPriority,
+        dueDate: parsedDueDate,
+        ownerId: owner.id,
+      },
+    });
+
+    return NextResponse.json(task, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create task", error);
+    return NextResponse.json(
+      { error: "Unable to create task" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,0 +1,449 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormEvent, useMemo, useState } from "react";
+
+type TaskStatus = "TODO" | "IN_PROGRESS" | "COMPLETED";
+type TaskPriority = "LOW" | "MEDIUM" | "HIGH";
+
+type Task = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CreateTaskInput = {
+  title: string;
+  description?: string | null;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  dueDate?: string | null;
+};
+
+type UpdateTaskInput = Partial<Omit<CreateTaskInput, "title">> & {
+  title?: string;
+};
+
+const statusOptions: { value: TaskStatus; label: string }[] = [
+  { value: "TODO", label: "To do" },
+  { value: "IN_PROGRESS", label: "In progress" },
+  { value: "COMPLETED", label: "Completed" },
+];
+
+const priorityOptions: { value: TaskPriority; label: string }[] = [
+  { value: "LOW", label: "Low" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "HIGH", label: "High" },
+];
+
+function formatDate(dateString: string | null) {
+  if (!dateString) {
+    return "No due date";
+  }
+
+  const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) {
+    return "No due date";
+  }
+
+  return date.toLocaleDateString();
+}
+
+async function fetchTasks(): Promise<Task[]> {
+  const response = await fetch("/api/tasks", {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload.error === "string" ? payload.error : "Failed to load tasks";
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+async function createTask(task: CreateTaskInput): Promise<Task> {
+  const response = await fetch("/api/tasks", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(task),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload.error === "string" ? payload.error : "Failed to create task";
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+async function updateTask(id: string, updates: UpdateTaskInput): Promise<Task> {
+  const response = await fetch(`/api/tasks/${id}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(updates),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload.error === "string" ? payload.error : "Failed to update task";
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+async function deleteTask(id: string): Promise<void> {
+  const response = await fetch(`/api/tasks/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload.error === "string" ? payload.error : "Failed to delete task";
+    throw new Error(message);
+  }
+}
+
+export default function TasksPage() {
+  const { data: session, status } = useSession();
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [priority, setPriority] = useState<TaskPriority>("MEDIUM");
+  const [statusFilter, setStatusFilter] = useState<TaskStatus | "ALL">("ALL");
+
+  const {
+    data: tasks,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: fetchTasks,
+    enabled: status === "authenticated",
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createTask,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      setTitle("");
+      setDescription("");
+      setDueDate("");
+      setPriority("MEDIUM");
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: UpdateTaskInput }) => updateTask(id, updates),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteTask,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+  });
+
+  const filteredTasks = useMemo(() => {
+    if (!tasks) {
+      return [];
+    }
+
+    if (statusFilter === "ALL") {
+      return tasks;
+    }
+
+    return tasks.filter((task) => task.status === statusFilter);
+  }, [tasks, statusFilter]);
+
+  const handleCreateTask = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!title.trim()) {
+      return;
+    }
+
+    const payload: CreateTaskInput = {
+      title: title.trim(),
+      description: description.trim() ? description.trim() : undefined,
+      priority,
+    };
+
+    if (dueDate) {
+      payload.dueDate = new Date(dueDate).toISOString();
+    }
+
+    createMutation.mutate(payload);
+  };
+
+  if (status === "loading") {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-gray-900">Task management</h1>
+        <p className="text-gray-600">Checking your session…</p>
+      </div>
+    );
+  }
+
+  if (status === "unauthenticated" || !session) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-gray-900">Task management</h1>
+        <p className="text-gray-600">
+          Please sign in to create and manage your tasks.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <section className="rounded-lg bg-white p-6 shadow">
+        <h1 className="text-3xl font-semibold text-gray-900">Task management</h1>
+        <p className="mt-2 text-gray-600">
+          Create new tasks, track their status, and stay on top of your priorities.
+        </p>
+
+        <form onSubmit={handleCreateTask} className="mt-6 space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="md:col-span-2">
+              <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
+                Task title
+              </label>
+              <input
+                id="task-title"
+                name="title"
+                type="text"
+                required
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                className="mt-2 w-full rounded-md border border-gray-300 px-4 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="What do you need to do?"
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <label htmlFor="task-description" className="block text-sm font-medium text-gray-700">
+                Description (optional)
+              </label>
+              <textarea
+                id="task-description"
+                name="description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={4}
+                className="mt-2 w-full rounded-md border border-gray-300 px-4 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="Add details that will help you complete this task."
+              />
+            </div>
+
+            <div>
+              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
+                Priority
+              </label>
+              <select
+                id="task-priority"
+                name="priority"
+                value={priority}
+                onChange={(event) => setPriority(event.target.value as TaskPriority)}
+                className="mt-2 w-full rounded-md border border-gray-300 px-4 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {priorityOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="task-due-date" className="block text-sm font-medium text-gray-700">
+                Due date
+              </label>
+              <input
+                id="task-due-date"
+                name="dueDate"
+                type="date"
+                value={dueDate}
+                onChange={(event) => setDueDate(event.target.value)}
+                className="mt-2 w-full rounded-md border border-gray-300 px-4 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          {createMutation.error instanceof Error && (
+            <p className="text-sm text-red-600">{createMutation.error.message}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={createMutation.isPending}
+            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {createMutation.isPending ? "Creating…" : "Add task"}
+          </button>
+        </form>
+      </section>
+
+      <section className="rounded-lg bg-white p-6 shadow">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-900">Your tasks</h2>
+            <p className="text-gray-600">Review progress and keep everything moving forward.</p>
+          </div>
+
+          <div>
+            <label htmlFor="status-filter" className="sr-only">
+              Filter tasks by status
+            </label>
+            <select
+              id="status-filter"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as TaskStatus | "ALL")}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="ALL">All statuses</option>
+              {statusOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-4">
+          {isLoading && <p className="text-gray-600">Loading your tasks…</p>}
+
+          {isError && error instanceof Error && (
+            <p className="text-sm text-red-600">{error.message}</p>
+          )}
+
+          {!isLoading && !isError && filteredTasks.length === 0 && (
+            <p className="text-gray-600">No tasks found. Add a task to get started.</p>
+          )}
+
+          {filteredTasks.map((task) => (
+            <article
+              key={task.id}
+              className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition hover:border-blue-400"
+            >
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold text-gray-900">{task.title}</h3>
+                  {task.description && (
+                    <p className="mt-1 text-gray-600">{task.description}</p>
+                  )}
+
+                  <dl className="mt-3 grid gap-3 text-sm text-gray-600 sm:grid-cols-2">
+                    <div>
+                      <dt className="font-medium text-gray-500">Status</dt>
+                      <dd className="mt-0.5 capitalize text-gray-900">
+                        {statusOptions.find((option) => option.value === task.status)?.label ?? task.status}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-gray-500">Priority</dt>
+                      <dd className="mt-0.5 capitalize text-gray-900">
+                        {priorityOptions.find((option) => option.value === task.priority)?.label ?? task.priority}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-gray-500">Due</dt>
+                      <dd className="mt-0.5 text-gray-900">{formatDate(task.dueDate)}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-gray-500">Last updated</dt>
+                      <dd className="mt-0.5 text-gray-900">{formatDate(task.updatedAt)}</dd>
+                    </div>
+                  </dl>
+                </div>
+
+                <div className="flex flex-col gap-3 md:w-56">
+                  <div>
+                    <label htmlFor={`status-${task.id}`} className="block text-sm font-medium text-gray-700">
+                      Update status
+                    </label>
+                    <select
+                      id={`status-${task.id}`}
+                      value={task.status}
+                      onChange={(event) =>
+                        updateMutation.mutate({
+                          id: task.id,
+                          updates: { status: event.target.value as TaskStatus },
+                        })
+                      }
+                      disabled={updateMutation.isPending}
+                      className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      {statusOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label htmlFor={`priority-${task.id}`} className="block text-sm font-medium text-gray-700">
+                      Update priority
+                    </label>
+                    <select
+                      id={`priority-${task.id}`}
+                      value={task.priority}
+                      onChange={(event) =>
+                        updateMutation.mutate({
+                          id: task.id,
+                          updates: { priority: event.target.value as TaskPriority },
+                        })
+                      }
+                      disabled={updateMutation.isPending}
+                      className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      {priorityOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => deleteMutation.mutate(task.id)}
+                    disabled={deleteMutation.isPending}
+                    className="inline-flex items-center justify-center rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 transition hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {deleteMutation.isPending ? "Removing…" : "Delete task"}
+                  </button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -20,10 +20,16 @@ export function Navbar() {
             {session ? (
               <>
                 <Link
-                  href="./dashboard"
+                  href="/dashboard"
                   className="text-gray-600 hover:text-gray-900"
                 >
                   Dashboard
+                </Link>
+                <Link
+                  href="/tasks"
+                  className="text-gray-600 hover:text-gray-900"
+                >
+                  Tasks
                 </Link>
                 <button
                   onClick={() => signOut()}


### PR DESCRIPTION
## Summary
- extend the Prisma schema with a Task model and supporting enums
- add authenticated task API routes for listing, creating, updating, and deleting personal tasks
- create a client-side task management page backed by React Query and expose it through the navigation

## Testing
- Not run (network restrictions prevented installing new dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e45346f89c8324a48a5949ea62d52e