### PR TITLE
Exclude frontend test files from TypeScript build

### DIFF
--- a/soft-sme-frontend/tsconfig.json
+++ b/soft-sme-frontend/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- exclude test files from the frontend TypeScript project so build does not require test globals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e455b075ac8324ad8946508bbdb16e