### PR TITLE
Implement task management endpoints and message deletion table

### DIFF
--- a/soft-sme-backend/migrations/20241105000000_create_message_deletions_table.sql
+++ b/soft-sme-backend/migrations/20241105000000_create_message_deletions_table.sql
@@ -1,0 +1,13 @@
+-- Ensure per-user message deletion tracking exists for the messaging module
+-- This table allows conversations to hide specific messages for a user
+-- without removing the original record for other participants.
+
+CREATE TABLE IF NOT EXISTS message_deletions (
+  message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  deleted_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (message_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_deletions_user ON message_deletions(user_id);
+CREATE INDEX IF NOT EXISTS idx_message_deletions_deleted_at ON message_deletions(deleted_at);

--- a/soft-sme-backend/src/routes/taskRoutes.ts
+++ b/soft-sme-backend/src/routes/taskRoutes.ts
@@ -6,9 +6,11 @@ import {
   TaskAccessError,
   TaskParticipant,
 } from '../services/TaskMessageService';
+import { ServiceError, TaskService, TaskStatus } from '../services/TaskService';
 
 const router = express.Router();
 const messageService = new TaskMessageService(pool);
+const taskService = new TaskService(pool);
 
 function parseId(value: unknown): number | null {
   if (typeof value === 'number') {
@@ -29,6 +31,361 @@ function ensureCompanyAccess(participant: TaskParticipant, companyId: number | n
   }
   return participant.companyId == null || participant.companyId === companyId;
 }
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') {
+      return true;
+    }
+    if (value.toLowerCase() === 'false') {
+      return false;
+    }
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return undefined;
+}
+
+function getCompanyId(req: Request): number | null {
+  return parseId(req.user?.company_id);
+}
+
+function getUserId(req: Request): number | null {
+  return parseId(req.user?.id);
+}
+
+function handleTaskError(res: Response, error: unknown, fallbackMessage: string) {
+  if (error instanceof ServiceError) {
+    return res.status(error.statusCode).json({ message: error.message });
+  }
+  console.error(fallbackMessage, error);
+  return res.status(500).json({ message: fallbackMessage });
+}
+
+function parseStatusList(value: unknown): TaskStatus[] | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+  const statuses = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0) as TaskStatus[];
+  return statuses.length > 0 ? statuses : undefined;
+}
+
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const companyId = getCompanyId(req);
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const filters: Record<string, unknown> = {};
+
+    const statuses = parseStatusList(req.query.status);
+    if (statuses) {
+      filters.status = statuses;
+    }
+
+    const assignedTo = parseId(req.query.assignedTo as string | undefined);
+    if (assignedTo) {
+      filters.assignedTo = assignedTo;
+    }
+
+    if (typeof req.query.dueFrom === 'string' && req.query.dueFrom.trim().length > 0) {
+      filters.dueFrom = req.query.dueFrom;
+    }
+
+    if (typeof req.query.dueTo === 'string' && req.query.dueTo.trim().length > 0) {
+      filters.dueTo = req.query.dueTo;
+    }
+
+    if (typeof req.query.search === 'string' && req.query.search.trim().length > 0) {
+      filters.search = req.query.search;
+    }
+
+    const includeCompleted = parseBoolean(req.query.includeCompleted);
+    if (typeof includeCompleted === 'boolean') {
+      filters.includeCompleted = includeCompleted;
+    }
+
+    const includeArchived = parseBoolean(req.query.includeArchived);
+    if (typeof includeArchived === 'boolean') {
+      filters.includeArchived = includeArchived;
+    }
+
+    const tasks = await taskService.listTasks(companyId, filters);
+    res.json({ tasks });
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to load tasks');
+  }
+});
+
+router.get('/summary', async (req: Request, res: Response) => {
+  try {
+    const companyId = getCompanyId(req);
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const summary = await taskService.getSummary(companyId);
+    res.json(summary);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to load task summary');
+  }
+});
+
+router.get('/assignees', async (req: Request, res: Response) => {
+  try {
+    const companyId = getCompanyId(req);
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const assignees = await taskService.getAssignableUsers(companyId);
+    res.json({ assignees });
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to load assignable users');
+  }
+});
+
+router.post('/', async (req: Request, res: Response) => {
+  try {
+    const companyId = getCompanyId(req);
+    const userId = getUserId(req);
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const payload = req.body ?? {};
+
+    const assigneeIds = Array.isArray(payload.assigneeIds)
+      ? payload.assigneeIds
+          .map((id: unknown) => parseId(id))
+          .filter((id: number | null): id is number => typeof id === 'number')
+      : [];
+
+    const task = await taskService.createTask(companyId, userId, {
+      title: typeof payload.title === 'string' ? payload.title : '',
+      description: typeof payload.description === 'string' ? payload.description : undefined,
+      status: typeof payload.status === 'string' ? (payload.status as TaskStatus) : undefined,
+      dueDate:
+        payload.dueDate === null
+          ? null
+          : typeof payload.dueDate === 'string'
+            ? payload.dueDate
+            : undefined,
+      assigneeIds,
+      initialNote: typeof payload.initialNote === 'string' ? payload.initialNote : undefined,
+    });
+
+    res.status(201).json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to create task');
+  }
+});
+
+router.get('/:taskId/overview', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const task = await taskService.getTask(companyId, taskId);
+    res.json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to load task');
+  }
+});
+
+router.put('/:taskId', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const updates = req.body ?? {};
+
+    const task = await taskService.updateTask(companyId, taskId, {
+      title: typeof updates.title === 'string' ? updates.title : undefined,
+      description:
+        updates.description === undefined
+          ? undefined
+          : typeof updates.description === 'string'
+            ? updates.description
+            : updates.description === null
+              ? ''
+              : undefined,
+      status: typeof updates.status === 'string' ? (updates.status as TaskStatus) : undefined,
+      dueDate:
+        updates.dueDate === undefined
+          ? undefined
+          : updates.dueDate === null
+            ? null
+            : typeof updates.dueDate === 'string'
+              ? updates.dueDate
+              : undefined,
+    });
+
+    res.json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to update task');
+  }
+});
+
+router.patch('/:taskId/assignments', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    const userId = getUserId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const { assigneeIds } = req.body ?? {};
+    if (!Array.isArray(assigneeIds)) {
+      return res.status(400).json({ message: 'assigneeIds must be an array' });
+    }
+
+    const normalized = assigneeIds
+      .map((id: unknown) => parseId(id))
+      .filter((id: number | null): id is number => typeof id === 'number');
+
+    const task = await taskService.updateAssignments(companyId, taskId, normalized, userId);
+    res.json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to update task assignments');
+  }
+});
+
+router.patch('/:taskId/due-date', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const { dueDate } = req.body ?? {};
+    if (dueDate !== null && typeof dueDate !== 'string') {
+      return res.status(400).json({ message: 'dueDate must be a string or null' });
+    }
+
+    const task = await taskService.updateDueDate(companyId, taskId, dueDate ?? null);
+    res.json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to update task due date');
+  }
+});
+
+router.patch('/:taskId/complete', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const { completed } = req.body ?? {};
+    if (typeof completed !== 'boolean') {
+      return res.status(400).json({ message: 'completed must be a boolean' });
+    }
+
+    const task = await taskService.toggleCompletion(companyId, taskId, completed);
+    res.json(task);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to update task completion');
+  }
+});
+
+router.post('/:taskId/notes', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    const userId = getUserId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'Invalid user context' });
+    }
+
+    const { note } = req.body ?? {};
+    if (typeof note !== 'string' || note.trim().length === 0) {
+      return res.status(400).json({ message: 'Note is required' });
+    }
+
+    const createdNote = await taskService.addNote(companyId, taskId, userId, note);
+    res.status(201).json(createdNote);
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to add note');
+  }
+});
+
+router.get('/:taskId/notes', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    const task = await taskService.getTask(companyId, taskId);
+    res.json({ notes: task.notes ?? [] });
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to load task notes');
+  }
+});
+
+router.delete('/:taskId', async (req: Request, res: Response) => {
+  try {
+    const taskId = parseId(req.params.taskId);
+    const companyId = getCompanyId(req);
+    if (!taskId) {
+      return res.status(400).json({ message: 'Invalid task id' });
+    }
+    if (!companyId) {
+      return res.status(400).json({ message: 'Invalid company context' });
+    }
+
+    await taskService.deleteTask(companyId, taskId);
+    res.status(204).send();
+  } catch (error) {
+    handleTaskError(res, error, 'Failed to delete task');
+  }
+});
 
 router.get('/:taskId/messages', async (req: Request, res: Response) => {
   try {

--- a/soft-sme-frontend/src/services/taskService.ts
+++ b/soft-sme-frontend/src/services/taskService.ts
@@ -46,7 +46,7 @@ export const getTasks = async (filters?: TaskFilters): Promise<Task[]> => {
 };
 
 export const getTaskById = async (taskId: number): Promise<Task> => {
-  const response = await api.get(`/api/tasks/${taskId}`);
+  const response = await api.get(`/api/tasks/${taskId}/overview`);
   return response.data as Task;
 };
 


### PR DESCRIPTION
## Summary
- add full task management REST endpoints, including listing, summary, assignments, notes, and deletion handlers
- expose an overview endpoint used by the frontend task dashboard and adjust the client to call it
- create a database migration to provision the message_deletions table referenced by messaging queries

## Testing
- npm run build (backend)
- CI=1 npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e45919964483248bb8e40a89faee28