### PR TITLE
Register task routes in production entrypoint

### DIFF
--- a/soft-sme-backend/src/index.ts
+++ b/soft-sme-backend/src/index.ts
@@ -44,6 +44,7 @@ import agentV2Routes from './routes/agentV2Routes';
 import voiceRoutes from './routes/voiceRoutes';
 import voiceStreamRoutes from './routes/voiceStreamRoutes';
 import voiceSearchRoutes from './routes/voiceSearchRoutes';
+import taskRoutes from './routes/taskRoutes';
 import aiAssistantService from './services/aiAssistantService';
 import partFinderRoutes from './routes/partFinderRoutes';
 import inventoryVendorRoutes from './routes/inventoryVendorRoutes';
@@ -198,6 +199,9 @@ console.log('Registered profile document routes');
 
 app.use('/api/messaging', authMiddleware, messagingRoutes);
 console.log('Registered messaging routes');
+
+app.use('/api/tasks', taskRoutes);
+console.log('Registered task routes');
 
 // Agent V2 routes (feature-flagged)
 if (process.env.AI_ASSISTANT_V2 !== 'false') {


### PR DESCRIPTION
## Summary
- import the task routes in the production server entrypoint
- register the /api/tasks endpoint so summary and assignee APIs are available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4690225648324a4ac3ae18baf1f75