### PR TITLE
Improve task dashboard visuals and fix editing bug

### DIFF
--- a/soft-sme-frontend/src/components/tasks/TaskCompletionToggle.tsx
+++ b/soft-sme-frontend/src/components/tasks/TaskCompletionToggle.tsx
@@ -16,7 +16,15 @@ const TaskCompletionToggle: React.FC<TaskCompletionToggleProps> = ({ completed, 
   return (
     <Tooltip title={completed ? 'Mark as incomplete' : 'Mark as completed'}>
       <FormControlLabel
-        control={<Switch checked={completed} onChange={handleChange} disabled={disabled} color="success" />}
+        control={
+          <Switch
+            checked={completed}
+            onChange={handleChange}
+            disabled={disabled}
+            color="success"
+            size="small"
+          />
+        }
         label={label ?? (completed ? 'Completed' : 'Mark complete')}
       />
     </Tooltip>

--- a/soft-sme-frontend/src/components/tasks/TaskFilters.tsx
+++ b/soft-sme-frontend/src/components/tasks/TaskFilters.tsx
@@ -9,6 +9,7 @@ import {
   ListItemText,
   MenuItem,
   OutlinedInput,
+  Paper,
   Select,
   SelectChangeEvent,
   Stack,
@@ -51,9 +52,22 @@ const TaskFiltersComponent: React.FC<TaskFiltersProps> = ({ filters, assignees, 
   };
 
   return (
-    <Box>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'flex-end' }}>
-        <FormControl sx={{ minWidth: 200 }} size="small">
+    <Paper
+      variant="outlined"
+      sx={{
+        p: { xs: 2.5, md: 3 },
+        borderRadius: 3,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', lg: 'row' }}
+        spacing={2}
+        useFlexGap
+        flexWrap="wrap"
+        alignItems={{ xs: 'stretch', lg: 'flex-end' }}
+      >
+        <FormControl sx={{ minWidth: 180, flex: '1 1 200px' }} size="small">
           <InputLabel id="task-status-label">Status</InputLabel>
           <Select
             labelId="task-status-label"
@@ -76,12 +90,12 @@ const TaskFiltersComponent: React.FC<TaskFiltersProps> = ({ filters, assignees, 
           </Select>
         </FormControl>
 
-        <FormControl sx={{ minWidth: 200 }} size="small">
-          <InputLabel id="task-assigned-label">Assigned To</InputLabel>
+        <FormControl sx={{ minWidth: 180, flex: '1 1 200px' }} size="small">
+          <InputLabel id="task-assigned-label">Assigned to</InputLabel>
           <Select
             labelId="task-assigned-label"
             value={filters.assignedTo ? String(filters.assignedTo) : ''}
-            label="Assigned To"
+            label="Assigned to"
             onChange={handleAssignedChange}
           >
             <MenuItem value="">
@@ -100,6 +114,7 @@ const TaskFiltersComponent: React.FC<TaskFiltersProps> = ({ filters, assignees, 
           size="small"
           value={filters.search ?? ''}
           onChange={handleInputChange('search')}
+          sx={{ flex: '1 1 200px' }}
         />
 
         <TextField
@@ -109,6 +124,7 @@ const TaskFiltersComponent: React.FC<TaskFiltersProps> = ({ filters, assignees, 
           value={filters.dueFrom?.slice(0, 10) ?? ''}
           onChange={handleInputChange('dueFrom')}
           InputLabelProps={{ shrink: true }}
+          sx={{ flex: '1 1 180px' }}
         />
 
         <TextField
@@ -118,25 +134,29 @@ const TaskFiltersComponent: React.FC<TaskFiltersProps> = ({ filters, assignees, 
           value={filters.dueTo?.slice(0, 10) ?? ''}
           onChange={handleInputChange('dueTo')}
           InputLabelProps={{ shrink: true }}
+          sx={{ flex: '1 1 180px' }}
         />
 
-        <FormControlLabel
-          control={<Checkbox checked={filters.includeCompleted ?? false} onChange={handleCheckboxChange('includeCompleted')} />}
-          label="Show completed"
-        />
-
-        <FormControlLabel
-          control={<Checkbox checked={filters.includeArchived ?? false} onChange={handleCheckboxChange('includeArchived')} />}
-          label="Show archived"
-        />
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, flex: '1 1 220px' }}>
+          <FormControlLabel
+            control={<Checkbox checked={filters.includeCompleted ?? false} onChange={handleCheckboxChange('includeCompleted')} />}
+            label="Show completed"
+          />
+          <FormControlLabel
+            control={<Checkbox checked={filters.includeArchived ?? false} onChange={handleCheckboxChange('includeArchived')} />}
+            label="Show archived"
+          />
+        </Box>
 
         {onReset && (
-          <Button variant="text" onClick={onReset} color="secondary">
-            Reset
-          </Button>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Button variant="text" onClick={onReset} color="secondary">
+              Reset
+            </Button>
+          </Box>
         )}
       </Stack>
-    </Box>
+    </Paper>
   );
 };
 

--- a/soft-sme-frontend/src/components/tasks/TaskFormDialog.tsx
+++ b/soft-sme-frontend/src/components/tasks/TaskFormDialog.tsx
@@ -20,7 +20,7 @@ import { Task, TaskAssignee, TaskStatus } from '../../types/task';
 
 export interface TaskFormValues {
   title: string;
-  description?: string;
+  description?: string | null;
   dueDate?: string | null;
   status?: TaskStatus;
   assigneeIds: number[];
@@ -103,14 +103,16 @@ const TaskFormDialog: React.FC<TaskFormDialogProps> = ({
   );
 
   const handleSubmit = async () => {
-    if (!title.trim()) {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
       setErrors({ title: 'Title is required' });
       return;
     }
 
+    const trimmedDescription = description.trim();
     const payload: TaskFormValues = {
-      title: title.trim(),
-      description: description.trim() || undefined,
+      title: trimmedTitle,
+      description: trimmedDescription.length > 0 ? trimmedDescription : null,
       dueDate: dueDate ? new Date(dueDate).toISOString() : null,
       status,
       assigneeIds: selectedAssignees,

--- a/soft-sme-frontend/src/components/tasks/TaskList.tsx
+++ b/soft-sme-frontend/src/components/tasks/TaskList.tsx
@@ -3,13 +3,12 @@ import {
   Avatar,
   AvatarGroup,
   Box,
+  Card,
+  CardActionArea,
+  CardActions,
   Chip,
   Divider,
   IconButton,
-  List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
   Stack,
   Tooltip,
   Typography,
@@ -17,6 +16,8 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import NotesIcon from '@mui/icons-material/Notes';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import ScheduleIcon from '@mui/icons-material/Schedule';
 import { Task } from '../../types/task';
 import TaskCompletionToggle from './TaskCompletionToggle';
 
@@ -53,88 +54,247 @@ const formatDate = (iso: string | null): string => {
   }).format(new Date(iso));
 };
 
+const relativeFormatter =
+  typeof Intl !== 'undefined' && 'RelativeTimeFormat' in Intl
+    ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+    : null;
+
+const formatRelativeTime = (iso: string | null): string => {
+  if (!iso) {
+    return 'Never';
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime()) || !relativeFormatter) {
+    return formatDate(iso);
+  }
+  const diffMs = date.getTime() - Date.now();
+  const abs = Math.abs(diffMs);
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ['day', 1000 * 60 * 60 * 24],
+    ['hour', 1000 * 60 * 60],
+    ['minute', 1000 * 60],
+  ];
+  for (const [unit, value] of units) {
+    if (abs >= value || unit === 'minute') {
+      const rounded = Math.round(diffMs / value);
+      return relativeFormatter.format(rounded, unit);
+    }
+  }
+  return relativeFormatter.format(0, 'minute');
+};
+
 const TaskList: React.FC<TaskListProps> = ({ tasks, onSelect, onToggleComplete, onEdit, onDelete }) => {
   if (tasks.length === 0) {
     return (
-      <Box textAlign="center" py={6} color="text.secondary">
+      <Box
+        textAlign="center"
+        py={6}
+        color="text.secondary"
+        sx={{
+          border: '1px dashed',
+          borderColor: 'divider',
+          borderRadius: 3,
+          backgroundColor: 'background.paper',
+        }}
+      >
         <NotesIcon sx={{ fontSize: 48, mb: 1 }} />
         <Typography variant="h6">No tasks found</Typography>
-        <Typography variant="body2">Create a task to get started.</Typography>
+        <Typography variant="body2">
+          Use the “New task” button above to create your first assignment.
+        </Typography>
       </Box>
     );
   }
 
   return (
-    <List disablePadding>
-      {tasks.map((task, index) => {
+    <Stack spacing={2.5}>
+      {tasks.map((task) => {
         const dueDate = task.dueDate ? new Date(task.dueDate) : null;
-        const isOverdue = dueDate && dueDate.getTime() < Date.now() && task.status !== 'completed';
+        const now = Date.now();
+        const isOverdue = Boolean(dueDate && dueDate.getTime() < now && task.status !== 'completed');
+        const diffDays =
+          dueDate && task.status !== 'completed'
+            ? Math.ceil((dueDate.getTime() - now) / (1000 * 60 * 60 * 24))
+            : null;
+        const isDueSoon = typeof diffDays === 'number' && diffDays >= 0 && diffDays <= 3;
+        const accentColor = isOverdue
+          ? 'error.main'
+          : task.status === 'completed'
+            ? 'success.main'
+            : isDueSoon
+              ? 'warning.main'
+              : 'info.main';
+
         return (
-          <React.Fragment key={task.id}>
-            <ListItem alignItems="flex-start" button onClick={() => onSelect(task)}>
-              <ListItemText
-                primary={
-                  <Stack direction="row" spacing={2} alignItems="center">
-                    <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                      {task.title}
-                    </Typography>
-                    <Chip
-                      label={STATUS_LABELS[task.status]}
-                      color={STATUS_COLOR[task.status]}
-                      size="small"
-                    />
+          <Card
+            key={task.id}
+            elevation={0}
+            sx={{
+              position: 'relative',
+              borderRadius: 3,
+              border: '1px solid',
+              borderColor: 'divider',
+              overflow: 'hidden',
+              transition: 'all 0.2s ease-in-out',
+              '&:hover': {
+                boxShadow: 8,
+                transform: 'translateY(-2px)',
+              },
+            }}
+          >
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                bottom: 0,
+                width: 6,
+                bgcolor: accentColor,
+              }}
+            />
+
+            <CardActionArea onClick={() => onSelect(task)} sx={{ alignSelf: 'stretch' }}>
+              <Box sx={{ p: { xs: 2.5, sm: 3 } }}>
+                <Stack spacing={2}>
+                  <Stack
+                    direction={{ xs: 'column', md: 'row' }}
+                    spacing={1.5}
+                    justifyContent="space-between"
+                    alignItems={{ xs: 'flex-start', md: 'center' }}
+                  >
+                    <Typography variant="h6">{task.title}</Typography>
+                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                      <Chip
+                        label={STATUS_LABELS[task.status]}
+                        color={STATUS_COLOR[task.status]}
+                        size="small"
+                      />
+                      {isOverdue && task.status !== 'completed' && (
+                        <Chip label="Overdue" color="error" size="small" variant="outlined" />
+                      )}
+                      {task.status === 'completed' && (
+                        <Chip
+                          label={`Completed ${formatRelativeTime(task.completedAt)}`}
+                          color="success"
+                          size="small"
+                          variant="outlined"
+                        />
+                      )}
+                    </Stack>
                   </Stack>
-                }
-                secondary={
-                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
-                    <Typography variant="body2" color={isOverdue ? 'error.main' : 'text.secondary'}>
-                      Due: {formatDate(task.dueDate)}
+
+                  {task.description && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      {task.description}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {task.noteCount} note{task.noteCount === 1 ? '' : 's'}
-                    </Typography>
-                    {task.assignees.length > 0 && (
-                      <AvatarGroup max={4} sx={{ '& .MuiAvatar-root': { width: 28, height: 28, fontSize: 14 } }}>
+                  )}
+
+                  <Stack
+                    direction={{ xs: 'column', md: 'row' }}
+                    spacing={2}
+                    justifyContent="space-between"
+                    alignItems={{ xs: 'flex-start', md: 'center' }}
+                  >
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                      <Chip
+                        icon={<CalendarTodayIcon fontSize="small" />}
+                        label={formatDate(task.dueDate)}
+                        color={isOverdue ? 'error' : isDueSoon ? 'warning' : 'default'}
+                        variant={task.dueDate ? 'filled' : 'outlined'}
+                        size="small"
+                      />
+                      <Chip
+                        icon={<NotesIcon fontSize="small" />}
+                        label={`${task.noteCount} note${task.noteCount === 1 ? '' : 's'}`}
+                        size="small"
+                        variant="outlined"
+                      />
+                      <Chip
+                        icon={<ScheduleIcon fontSize="small" />}
+                        label={`Updated ${formatRelativeTime(task.updatedAt)}`}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </Stack>
+
+                    {task.assignees.length > 0 ? (
+                      <AvatarGroup
+                        max={4}
+                        sx={{ '& .MuiAvatar-root': { width: 32, height: 32, fontSize: 14 } }}
+                      >
                         {task.assignees.map((assignee) => (
-                          <Tooltip title={assignee.username || assignee.email} key={`${task.id}-assignee-${assignee.id}`}>
+                          <Tooltip
+                            title={assignee.username || assignee.email}
+                            key={`${task.id}-assignee-${assignee.id}`}
+                          >
                             <Avatar>
                               {(assignee.username || assignee.email || '?').charAt(0).toUpperCase()}
                             </Avatar>
                           </Tooltip>
                         ))}
                       </AvatarGroup>
+                    ) : (
+                      <Chip label="Unassigned" size="small" variant="outlined" />
                     )}
                   </Stack>
-                }
-              />
-
-              <ListItemSecondaryAction>
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Box onClick={(event) => event.stopPropagation()}>
-                    <TaskCompletionToggle
-                      completed={task.status === 'completed'}
-                      onToggle={(completed) => onToggleComplete(task, completed)}
-                      label=""
-                    />
-                  </Box>
-                  <Tooltip title="Edit task">
-                    <IconButton edge="end" onClick={(event) => { event.stopPropagation(); onEdit(task); }}>
-                      <EditIcon />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Delete task">
-                    <IconButton edge="end" color="error" onClick={(event) => { event.stopPropagation(); onDelete(task); }}>
-                      <DeleteIcon />
-                    </IconButton>
-                  </Tooltip>
                 </Stack>
-              </ListItemSecondaryAction>
-            </ListItem>
-            {index < tasks.length - 1 && <Divider component="li" />}
-          </React.Fragment>
+              </Box>
+            </CardActionArea>
+
+            <Divider />
+
+            <CardActions
+              sx={{
+                px: { xs: 2, sm: 3 },
+                py: 1.5,
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Box onClick={(event) => event.stopPropagation()} sx={{ display: 'flex', alignItems: 'center' }}>
+                <TaskCompletionToggle
+                  completed={task.status === 'completed'}
+                  onToggle={(completed) => onToggleComplete(task, completed)}
+                  label={task.status === 'completed' ? 'Completed' : 'Mark complete'}
+                />
+              </Box>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Tooltip title="Edit task">
+                  <IconButton
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onEdit(task);
+                    }}
+                  >
+                    <EditIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete task">
+                  <IconButton
+                    color="error"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(task);
+                    }}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            </CardActions>
+          </Card>
         );
       })}
-    </List>
+    </Stack>
   );
 };
 

--- a/soft-sme-frontend/src/components/tasks/TaskSummaryWidget.tsx
+++ b/soft-sme-frontend/src/components/tasks/TaskSummaryWidget.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CircularProgress,
-  Grid,
-  Stack,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Card, CardContent, CircularProgress, Stack, Typography } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import PendingActionsIcon from '@mui/icons-material/PendingActions';
 import EventBusyIcon from '@mui/icons-material/EventBusy';
 import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
+import { alpha } from '@mui/material/styles';
 import { TaskSummary } from '../../types/task';
 
 interface TaskSummaryWidgetProps {
@@ -27,92 +19,156 @@ interface TaskSummaryWidgetProps {
 const METRIC_CONFIG = [
   {
     key: 'open' as const,
-    label: 'Open Tasks',
-    icon: <PendingActionsIcon color="info" fontSize="large" />,
+    label: 'Open tasks',
+    icon: <PendingActionsIcon fontSize="large" />,
+    palette: 'info' as const,
   },
   {
     key: 'completed' as const,
     label: 'Completed',
-    icon: <AssignmentTurnedInIcon color="success" fontSize="large" />,
+    icon: <AssignmentTurnedInIcon fontSize="large" />,
+    palette: 'success' as const,
   },
   {
     key: 'overdue' as const,
     label: 'Overdue',
-    icon: <EventBusyIcon color="error" fontSize="large" />,
+    icon: <EventBusyIcon fontSize="large" />,
+    palette: 'error' as const,
   },
   {
     key: 'dueToday' as const,
-    label: 'Due Today',
-    icon: <EventAvailableIcon color="warning" fontSize="large" />,
+    label: 'Due today',
+    icon: <EventAvailableIcon fontSize="large" />,
+    palette: 'warning' as const,
   },
   {
     key: 'dueSoon' as const,
-    label: 'Due in 7 Days',
-    icon: <PlaylistAddCheckIcon color="secondary" fontSize="large" />,
+    label: 'Due in 7 days',
+    icon: <PlaylistAddCheckIcon fontSize="large" />,
+    palette: 'secondary' as const,
   },
 ];
 
 const TaskSummaryWidget: React.FC<TaskSummaryWidgetProps> = ({ summary, loading, onRefresh, onViewTasks }) => {
+  const totalTasks = summary?.total ?? 0;
+
   return (
-    <Card sx={{ borderRadius: 3, boxShadow: 4 }}>
-      <CardContent>
-        <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ xs: 'flex-start', sm: 'center' }} spacing={2}>
+    <Card
+      sx={{
+        borderRadius: 3,
+        overflow: 'hidden',
+        position: 'relative',
+        boxShadow: '0 24px 60px -32px rgba(15, 23, 42, 0.45)',
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          background: 'linear-gradient(140deg, rgba(59, 130, 246, 0.12) 0%, rgba(99, 102, 241, 0.08) 45%, rgba(168, 85, 247, 0.05) 100%)',
+          pointerEvents: 'none',
+        }}
+      />
+      <CardContent sx={{ position: 'relative', p: { xs: 3, md: 4 } }}>
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+          spacing={3}
+        >
           <Box>
-            <Typography variant="h5" gutterBottom>
-              Task Overview
+            <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: 1.2 }}>
+              Team workload snapshot
             </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Stay on top of the work that needs attention.
+            <Typography variant="h4" sx={{ fontWeight: 600 }}>
+              Task overview
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5 }}>
+              Tracking <strong>{totalTasks}</strong> task{totalTasks === 1 ? '' : 's'} across your workspace.
             </Typography>
           </Box>
-          <Stack direction="row" spacing={1}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} width={{ xs: '100%', sm: 'auto' }}>
             {onRefresh && (
-              <Button variant="outlined" startIcon={<RefreshIcon />} onClick={onRefresh} disabled={loading}>
+              <Button
+                variant="outlined"
+                startIcon={<RefreshIcon />}
+                onClick={onRefresh}
+                disabled={loading}
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
+              >
                 Refresh
               </Button>
             )}
             {onViewTasks && (
-              <Button variant="contained" onClick={onViewTasks}>
+              <Button
+                variant="contained"
+                onClick={onViewTasks}
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
+              >
                 View tasks
               </Button>
             )}
           </Stack>
         </Stack>
 
-        <Box sx={{ mt: 3 }}>
+        <Box sx={{ mt: 4 }}>
           {loading ? (
             <Box display="flex" justifyContent="center" py={4}>
               <CircularProgress />
             </Box>
           ) : summary ? (
-            <Grid container spacing={2}>
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 2.5,
+                gridTemplateColumns: {
+                  xs: 'repeat(1, minmax(0, 1fr))',
+                  sm: 'repeat(2, minmax(0, 1fr))',
+                  md: 'repeat(3, minmax(0, 1fr))',
+                  lg: 'repeat(5, minmax(0, 1fr))',
+                },
+              }}
+            >
               {METRIC_CONFIG.map((metric) => (
-                <Grid item xs={12} sm={6} md={2} key={metric.key}>
-                  <Box
-                    sx={{
-                      borderRadius: 2,
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      p: 2,
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      textAlign: 'center',
-                      gap: 1,
-                    }}
-                  >
-                    {metric.icon}
-                    <Typography variant="h6">
-                      {summary[metric.key] ?? 0}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
+                <Box
+                  key={metric.key}
+                  sx={(theme) => ({
+                    borderRadius: 3,
+                    p: 3,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                    border: `1px solid ${alpha(theme.palette[metric.palette].main, 0.28)}`,
+                    background: `linear-gradient(135deg, ${alpha(theme.palette[metric.palette].main, 0.18)} 0%, ${alpha(theme.palette[metric.palette].main, 0.06)} 100%)`,
+                    boxShadow: `0 12px 30px -20px ${alpha(theme.palette[metric.palette].main, 0.6)}`,
+                    color: theme.palette.text.primary,
+                  })}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+                    <Box
+                      sx={(theme) => ({
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: 40,
+                        height: 40,
+                        borderRadius: '50%',
+                        backgroundColor: alpha(theme.palette[metric.palette].main, 0.2),
+                        color: theme.palette[metric.palette].dark,
+                      })}
+                    >
+                      {metric.icon}
+                    </Box>
+                    <Typography variant="subtitle2" color="text.secondary">
                       {metric.label}
                     </Typography>
                   </Box>
-                </Grid>
+                  <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                    {summary[metric.key] ?? 0}
+                  </Typography>
+                </Box>
               ))}
-            </Grid>
+            </Box>
           ) : (
             <Typography variant="body2" color="text.secondary">
               Task data is not available yet. Create your first task to populate this overview.

--- a/soft-sme-frontend/src/types/task.ts
+++ b/soft-sme-frontend/src/types/task.ts
@@ -52,7 +52,7 @@ export interface TaskFilters {
 
 export interface TaskPayload {
   title: string;
-  description?: string;
+  description?: string | null;
   dueDate?: string | null;
   status?: TaskStatus;
   assigneeIds?: number[];
@@ -61,7 +61,7 @@ export interface TaskPayload {
 
 export interface TaskUpdatePayload {
   title?: string;
-  description?: string;
+  description?: string | null;
   status?: TaskStatus;
   dueDate?: string | null;
 }


### PR DESCRIPTION
## Summary
- refresh the task dashboard with card-based task rows, updated summary metrics, and a cleaner filter panel
- allow task descriptions to be cleared and skip redundant assignment updates when no changes are requested
- tighten task completion toggle styling and enhance detail chips to highlight due dates, notes, and activity timing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4711b9d1083248c58fc1cb6df4213