### PR TITLE
Revamp messaging board UI

### DIFF
--- a/soft-sme-frontend/src/components/ChatInput.tsx
+++ b/soft-sme-frontend/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, KeyboardEvent } from 'react';
-import { Box, TextField, IconButton, Paper } from '@mui/material';
+import { Box, TextField, IconButton, Paper, Tooltip } from '@mui/material';
 import { Send as SendIcon } from '@mui/icons-material';
 
 interface ChatInputProps {
@@ -36,44 +36,82 @@ const ChatInput: React.FC<ChatInputProps> = ({
         p: 2,
         borderTop: 1,
         borderColor: 'divider',
+        bgcolor: 'background.paper',
+        borderRadius: 0,
+        boxShadow: '0 -8px 24px -20px rgba(15, 23, 42, 0.65)',
       }}
     >
-      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-end' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          bgcolor: 'grey.50',
+          borderRadius: '18px',
+          px: 2,
+          py: 1.25,
+          border: 1,
+          borderColor: 'grey.200',
+          boxShadow: 'inset 0 1px 2px rgba(15, 23, 42, 0.04)',
+        }}
+      >
         <TextField
           fullWidth
           multiline
           maxRows={4}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyPress}
           placeholder={placeholder}
           disabled={disabled}
           variant="outlined"
           size="small"
           sx={{
+            '& .MuiOutlinedInput-notchedOutline': {
+              border: 'none',
+            },
             '& .MuiOutlinedInput-root': {
-              borderRadius: 2,
+              borderRadius: '16px',
+              bgcolor: 'transparent',
+              fontSize: 14,
+              '& textarea': {
+                lineHeight: 1.6,
+              },
             },
           }}
         />
-        <IconButton
-          color="primary"
-          onClick={handleSend}
-          disabled={!message.trim() || disabled}
-          sx={{
-            bgcolor: 'primary.main',
-            color: 'white',
-            '&:hover': {
-              bgcolor: 'primary.dark',
-            },
-            '&.Mui-disabled': {
-              bgcolor: 'grey.300',
-              color: 'grey.500',
-            },
-          }}
-        >
-          <SendIcon />
-        </IconButton>
+        <Tooltip title="Send message">
+          <span>
+            <IconButton
+              color="primary"
+              onClick={handleSend}
+              disabled={!message.trim() || disabled}
+              sx={{
+                bgcolor: 'primary.main',
+                color: 'white',
+                p: 1.25,
+                borderRadius: '16px',
+                transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+                boxShadow: (theme) =>
+                  `0 12px 25px -15px ${theme.palette.primary.main}`,
+                '&:hover': {
+                  bgcolor: 'primary.dark',
+                  transform: 'translateY(-1px)',
+                  boxShadow: (theme) =>
+                    `0 14px 28px -16px ${theme.palette.primary.dark}`,
+                },
+                '&.Mui-disabled': {
+                  bgcolor: 'grey.300',
+                  color: 'grey.500',
+                  boxShadow: 'none',
+                  transform: 'none',
+                },
+              }}
+            >
+              <SendIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
       </Box>
     </Paper>
   );

--- a/soft-sme-frontend/src/components/ChatMessage.tsx
+++ b/soft-sme-frontend/src/components/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Typography, Paper, Avatar } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { Person as PersonIcon, SmartToy as AIIcon } from '@mui/icons-material';
 
 export interface ChatMessage {
@@ -16,68 +17,93 @@ interface ChatMessageProps {
 const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
   const isUser = message.sender === 'user';
 
+  const timestamp = message.timestamp.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
   return (
     <Box
       sx={{
         display: 'flex',
         justifyContent: isUser ? 'flex-end' : 'flex-start',
-        mb: 2,
-        gap: 1,
+        mb: 0.5,
+        pr: isUser ? 0 : 4,
+        pl: isUser ? 4 : 0,
       }}
     >
-      {!isUser && (
-        <Avatar
-          sx={{
-            bgcolor: 'primary.main',
-            width: 32,
-            height: 32,
-          }}
-        >
-          <AIIcon fontSize="small" />
-        </Avatar>
-      )}
-      
-      <Paper
-        elevation={1}
+      <Box
         sx={{
-          maxWidth: '70%',
-          p: 2,
-          bgcolor: isUser ? 'primary.main' : 'grey.100',
-          color: isUser ? 'white' : 'text.primary',
-          borderRadius: 2,
-          wordWrap: 'break-word',
+          display: 'flex',
+          alignItems: 'flex-end',
+          flexDirection: isUser ? 'row-reverse' : 'row',
+          gap: 1.5,
+          maxWidth: '100%',
         }}
       >
-        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-          {message.text}
-        </Typography>
-        <Typography
-          variant="caption"
-          sx={{
-            display: 'block',
-            mt: 0.5,
-            opacity: 0.7,
-            textAlign: isUser ? 'right' : 'left',
-          }}
-        >
-          {message.timestamp.toLocaleTimeString([], { 
-            hour: '2-digit', 
-            minute: '2-digit' 
-          })}
-        </Typography>
-      </Paper>
-
-      {isUser && (
         <Avatar
           sx={{
-            bgcolor: 'secondary.main',
-            width: 32,
-            height: 32,
+            bgcolor: isUser ? 'secondary.main' : 'primary.main',
+            width: 36,
+            height: 36,
+            boxShadow: 2,
           }}
         >
-          <PersonIcon fontSize="small" />
+          {isUser ? <PersonIcon fontSize="small" /> : <AIIcon fontSize="small" />}
         </Avatar>
-      )}
+
+        <Paper
+          elevation={0}
+          sx={{
+            position: 'relative',
+            px: 2.5,
+            py: 1.75,
+            maxWidth: { xs: '78%', sm: '70%' },
+            bgcolor: isUser
+              ? 'primary.main'
+              : (theme) => alpha(theme.palette.primary.main, 0.08),
+            color: isUser ? 'common.white' : 'text.primary',
+            borderRadius: '24px',
+            borderBottomRightRadius: isUser ? '12px' : '24px',
+            borderBottomLeftRadius: isUser ? '24px' : '12px',
+            boxShadow: (theme) =>
+              `0 12px 25px -18px ${alpha(theme.palette.primary.main, 0.6)}`,
+            backdropFilter: 'blur(6px)',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.75 }}>
+            <Typography
+              variant="caption"
+              sx={{
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: 0.6,
+                opacity: isUser ? 0.9 : 0.7,
+              }}
+            >
+              {isUser ? 'You' : 'Soft SME AI'}
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{
+                opacity: isUser ? 0.75 : 0.6,
+              }}
+            >
+              {timestamp}
+            </Typography>
+          </Box>
+
+          <Typography
+            variant="body2"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              lineHeight: 1.6,
+            }}
+          >
+            {message.text}
+          </Typography>
+        </Paper>
+      </Box>
     </Box>
   );
 };

--- a/soft-sme-frontend/src/components/ChatWindow.tsx
+++ b/soft-sme-frontend/src/components/ChatWindow.tsx
@@ -7,9 +7,14 @@ import {
   Button,
   Divider,
   CircularProgress,
+  Chip,
+  Avatar,
+  Tooltip,
 } from '@mui/material';
 import {
   Close as CloseIcon,
+  SmartToy as SmartToyIcon,
+  KeyboardDoubleArrowDown as KeyboardDoubleArrowDownIcon,
 } from '@mui/icons-material';
 import ChatMessage from './ChatMessage';
 import ChatInput from './ChatInput';
@@ -35,6 +40,10 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
     }
   };
 
+  const handleScrollToLatest = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <Drawer
       anchor="right"
@@ -42,52 +51,117 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
       onClose={onClose}
       sx={{
         '& .MuiDrawer-paper': {
-          width: { xs: '100%', sm: 400 },
+          width: { xs: '100%', sm: 420, md: 480 },
           maxWidth: '100vw',
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
+          bgcolor: 'background.default',
+          backgroundImage:
+            'linear-gradient(180deg, rgba(245, 247, 250, 0.95) 0%, rgba(255, 255, 255, 0.95) 40%, rgba(245, 247, 250, 0.9) 100%)',
         },
       }}
     >
       {/* Header */}
       <Box
         sx={{
-          p: 2,
+          px: 3,
+          py: 2,
           borderBottom: 1,
           borderColor: 'divider',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          bgcolor: 'primary.main',
-          color: 'white',
+          gap: 2,
+          bgcolor: 'transparent',
+          position: 'relative',
+          '&::after': {
+            content: "''",
+            position: 'absolute',
+            inset: 0,
+            background:
+              'linear-gradient(135deg, rgba(33, 150, 243, 0.12) 0%, rgba(3, 169, 244, 0.08) 55%, rgba(129, 199, 132, 0.12) 100%)',
+            zIndex: -1,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          },
         }}
       >
-        <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-          AI Assistant
-        </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleClearMessages}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Avatar
             sx={{
-              color: 'white',
-              borderColor: 'white',
-              '&:hover': {
-                borderColor: 'white',
-                bgcolor: 'rgba(255, 255, 255, 0.1)',
-              },
-              textTransform: 'none',
-              fontSize: '0.75rem',
-              px: 1,
-              py: 0.5,
+              bgcolor: 'primary.main',
+              width: 48,
+              height: 48,
+              boxShadow: 3,
             }}
           >
-            Clear Chat
-          </Button>
-          <IconButton color="inherit" onClick={onClose} size="small">
-            <CloseIcon />
+            <SmartToyIcon />
+          </Avatar>
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              AI Assistant
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Chip
+                size="small"
+                label="Online"
+                color="success"
+                sx={{ fontWeight: 600, px: 0.5 }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                Ask anything about your workspace
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Tooltip title="Jump to latest message">
+            <IconButton
+              color="primary"
+              size="small"
+              onClick={handleScrollToLatest}
+              sx={{
+                bgcolor: 'white',
+                border: 1,
+                borderColor: 'divider',
+                '&:hover': {
+                  bgcolor: 'grey.50',
+                },
+              }}
+            >
+              <KeyboardDoubleArrowDownIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Clear conversation">
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={handleClearMessages}
+              sx={{
+                textTransform: 'none',
+                fontWeight: 600,
+                px: 1.5,
+                borderRadius: 2,
+              }}
+            >
+              Clear Chat
+            </Button>
+          </Tooltip>
+          <IconButton
+            color="default"
+            onClick={onClose}
+            size="small"
+            sx={{
+              bgcolor: 'white',
+              border: 1,
+              borderColor: 'divider',
+              '&:hover': {
+                bgcolor: 'grey.50',
+              },
+            }}
+          >
+            <CloseIcon fontSize="small" />
           </IconButton>
         </Box>
       </Box>
@@ -97,10 +171,13 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
         sx={{
           flex: 1,
           overflow: 'auto',
-          p: 2,
+          px: { xs: 2, sm: 3 },
+          py: 3,
           display: 'flex',
           flexDirection: 'column',
-          gap: 1,
+          gap: 2,
+          backgroundImage:
+            'radial-gradient(circle at top, rgba(33, 150, 243, 0.08), transparent 55%)',
         }}
       >
         {messages.length === 0 ? (
@@ -115,13 +192,12 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
               color: 'text.secondary',
             }}
           >
-            <Typography variant="h6" gutterBottom>
-              Welcome to AI Assistant
+            <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
+              Welcome to your AI workspace
             </Typography>
-            <Typography variant="body2">
-              I'm here to help you with your business management tasks.
-              <br />
-              Ask me anything about inventory, customers, orders, or time tracking!
+            <Typography variant="body2" sx={{ maxWidth: 320 }}>
+              Ask about inventory, customers, orders, time tracking, or anything else
+              you need. I will keep the conversation tidy and actionable.
             </Typography>
           </Box>
         ) : (
@@ -137,22 +213,25 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
                   display: 'flex',
                   justifyContent: 'flex-start',
                   mb: 2,
-                  gap: 1,
                 }}
               >
                 <Box
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 1,
-                    p: 2,
-                    bgcolor: 'grey.100',
-                    borderRadius: 2,
+                    gap: 1.5,
+                    px: 2,
+                    py: 1.25,
+                    bgcolor: 'background.paper',
+                    borderRadius: 3,
+                    border: 1,
+                    borderColor: 'divider',
+                    boxShadow: 2,
                   }}
                 >
-                  <CircularProgress size={16} />
+                  <CircularProgress size={16} thickness={5} />
                   <Typography variant="body2" color="text.secondary">
-                    AI is typing...
+                    AI is drafting a response…
                   </Typography>
                 </Box>
               </Box>


### PR DESCRIPTION
## Summary
- refresh the AI assistant drawer with a gradient header, presence chip, and quick controls
- modernize individual chat message bubbles with avatar styling, metadata, and softened layout
- restyle the composer with rounded input, tooltip-enhanced send action, and smoother keyboard handling

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68e47994bdd883249f3160ff6161b0b0