### PR TITLE
Ensure Render build verifies apt dependencies

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -27,10 +27,12 @@ git push origin main
 4. **Connect your GitHub repository**
 5. **Configure the service:**
    - **Name**: `soft-sme-backend`
+   - **Root Directory**: `soft-sme-backend` (ensures Render sees `apt.txt` and installs Tesseract/Poppler before the build)
    - **Environment**: `Node`
-   - **Build Command**: `npm install && npm run build`
+   - **Build Command**: `./render-build.sh` (the script now verifies `apt.txt` is present and that Render installed the OCR tools from it; if not, the build fails with clear instructions)
    - **Start Command**: `npm start`
    - **Plan**: Free (or choose paid plan)
+   - _Render automatically installs the packages listed in `soft-sme-backend/apt.txt`; do not remove or rename this file._
 6. **Click "Create Web Service"**
 
 #### Option B: Blueprint Deployment

--- a/soft-sme-backend/render-build.sh
+++ b/soft-sme-backend/render-build.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure required OCR system packages are installed. Render's Node environment
-# is Debian-based, so we can use apt-get when the binaries are missing.
+# Ensure the Render build uses the backend directory as the root so `apt.txt`
+# is visible to the platform-level apt installer. Without it the OCR binaries
+# never get provisioned and the build fails later when the app boots.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APT_FILE="${SCRIPT_DIR}/apt.txt"
+
+if [[ ! -f "${APT_FILE}" ]]; then
+  cat <<'EOF'
+ERROR: Expected to find soft-sme-backend/apt.txt next to render-build.sh.
+Render only installs Tesseract/Poppler automatically when that file is present
+in the service root. Please restore the file or update the Render service's
+root directory to point at soft-sme-backend.
+EOF
+  exit 1
+fi
+
+# Render should have already installed the packages from apt.txt before this
+# script runs. If Tesseract is still missing we fail fast with an actionable
+# message instead of attempting apt-get (which is blocked in the sandbox).
 if ! command -v tesseract >/dev/null 2>&1; then
-  echo "Installing Tesseract OCR dependencies via apt-get..."
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    tesseract-ocr \
-    tesseract-ocr-eng \
-    poppler-utils
-  rm -rf /var/lib/apt/lists/*
-else
-  echo "Tesseract OCR already available; skipping apt-get install."
+  cat <<'EOF'
+ERROR: Tesseract is not available even though apt.txt is present.
+Render installs the packages listed in apt.txt during the dependency phase.
+Double-check that the service root is soft-sme-backend and redeploy so the
+platform can provision the OCR packages.
+EOF
+  exit 1
 fi
 
 npm install --include=dev


### PR DESCRIPTION
## Summary
- update render-build.sh to require soft-sme-backend/apt.txt and fail with guidance if Tesseract is missing
- adjust the deployment checklist description of the build command to match the new safety checks

## Testing
- not run (build-script/documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e47a275a588324861f59687ee88191