### PR TITLE
Allow render build script to self-install OCR deps

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -27,10 +27,12 @@ git push origin main
 4. **Connect your GitHub repository**
 5. **Configure the service:**
    - **Name**: `soft-sme-backend`
+   - **Root Directory**: `soft-sme-backend` (ensures Render sees `apt.txt` so the build script can install the OCR packages when needed)
    - **Environment**: `Node`
-   - **Build Command**: `npm install && npm run build`
+   - **Build Command**: `./render-build.sh` (the script ensures `apt.txt` exists and will install the OCR tools from it with a tmp `apt` cache if Render did not preinstall them)
    - **Start Command**: `npm start`
    - **Plan**: Free (or choose paid plan)
+   - _Render automatically installs the packages listed in `soft-sme-backend/apt.txt`; do not remove or rename this file._
 6. **Click "Create Web Service"**
 
 #### Option B: Blueprint Deployment

--- a/soft-sme-backend/render-build.sh
+++ b/soft-sme-backend/render-build.sh
@@ -1,18 +1,49 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure required OCR system packages are installed. Render's Node environment
-# is Debian-based, so we can use apt-get when the binaries are missing.
+# Ensure the Render build uses the backend directory as the root so `apt.txt`
+# is visible to the platform-level apt installer. Without it the OCR binaries
+# never get provisioned and the build fails later when the app boots.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APT_FILE="${SCRIPT_DIR}/apt.txt"
+
+if [[ ! -f "${APT_FILE}" ]]; then
+  cat <<'EOF'
+ERROR: Expected to find soft-sme-backend/apt.txt next to render-build.sh.
+Render only installs Tesseract/Poppler automatically when that file is present
+in the service root. Please restore the file or update the Render service's
+root directory to point at soft-sme-backend.
+EOF
+  exit 1
+fi
+
+mapfile -t APT_PACKAGES < <(grep -Ev '^(#|\s*$)' "${APT_FILE}")
+
 if ! command -v tesseract >/dev/null 2>&1; then
-  echo "Installing Tesseract OCR dependencies via apt-get..."
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    tesseract-ocr \
-    tesseract-ocr-eng \
-    poppler-utils
-  rm -rf /var/lib/apt/lists/*
-else
-  echo "Tesseract OCR already available; skipping apt-get install."
+  if ((${#APT_PACKAGES[@]} == 0)); then
+    cat <<'EOF'
+ERROR: apt.txt is present but does not list any packages to install.
+Please add the required OCR packages (e.g., tesseract-ocr) and redeploy.
+EOF
+    exit 1
+  fi
+
+  echo "Tesseract not found; installing packages from apt.txt..."
+
+  export DEBIAN_FRONTEND=noninteractive
+  APT_CACHE_DIR="${TMPDIR:-/tmp}/render-apt-cache"
+  APT_STATE_DIR="${TMPDIR:-/tmp}/render-apt-state"
+  mkdir -p "${APT_CACHE_DIR}/archives/partial" \
+           "${APT_STATE_DIR}/lists/partial"
+
+  APT_OPTS=(
+    "-o" "Dir::Cache=${APT_CACHE_DIR}"
+    "-o" "Dir::State=${APT_STATE_DIR}"
+    "-o" "Dir::State::status=/var/lib/dpkg/status"
+  )
+
+  apt-get update "${APT_OPTS[@]}"
+  apt-get install -y --no-install-recommends "${APT_OPTS[@]}" "${APT_PACKAGES[@]}"
 fi
 
 npm install --include=dev


### PR DESCRIPTION
## Summary
- update render-build.sh to install packages from apt.txt when Tesseract is missing using temporary apt cache/state directories
- adjust the deployment checklist description of the Render build command to reflect the new installation behavior

## Testing
- shellcheck soft-sme-backend/render-build.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e47a275a588324861f59687ee88191