### PR TITLE
Align Render blueprint with backend root

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -27,17 +27,19 @@ git push origin main
 4. **Connect your GitHub repository**
 5. **Configure the service:**
    - **Name**: `soft-sme-backend`
+   - **Root Directory**: `soft-sme-backend` (matches the blueprint configuration so Render sees `apt.txt` and preinstalls the OCR packages)
    - **Environment**: `Node`
-   - **Build Command**: `npm install && npm run build`
+   - **Build Command**: `./render-build.sh` (logs whether `apt.txt` was detected and then runs the Node build)
    - **Start Command**: `npm start`
    - **Plan**: Free (or choose paid plan)
+   - _Render automatically installs the packages listed in `soft-sme-backend/apt.txt`; do not remove or rename this file._
 6. **Click "Create Web Service"**
 
 #### Option B: Blueprint Deployment
 1. **Go to [render.com](https://render.com)**
 2. **Click "New +"** → **"Blueprint"**
 3. **Connect your GitHub repository**
-4. **Render will automatically detect `render.yaml`**
+4. **Render will automatically detect `render.yaml`** (which pins `rootDir: soft-sme-backend` so the platform installs the OCR packages from `apt.txt`)
 
 ### 3. Set Up Database
 1. **In your web service dashboard**

--- a/soft-sme-backend/RENDER_DEPLOYMENT.md
+++ b/soft-sme-backend/RENDER_DEPLOYMENT.md
@@ -21,8 +21,9 @@ Make sure your backend code is pushed to GitHub with these files:
 3. Connect your GitHub repository
 4. Configure the service:
    - **Name**: `soft-sme-backend`
+   - **Root Directory**: `soft-sme-backend`
    - **Environment**: `Node`
-   - **Build Command**: `./render-build.sh` (or `npm install --include=dev && npm run build` if you cannot use scripts)
+   - **Build Command**: `./render-build.sh` (logs whether `apt.txt` was detected and runs the Node build)
    - **Start Command**: `npm start`
    - **Plan**: Free (or choose paid plan)
 
@@ -77,7 +78,7 @@ After deployment, you may need to run database migrations:
 - Check that all dependencies are in `package.json`
 - Verify TypeScript compilation works locally
 - Check build logs in Render dashboard
-- Confirm `apt.txt` exists at the repository root so Render installs `tesseract-ocr`, `tesseract-ocr-eng`, and `poppler-utils`
+- Confirm `apt.txt` exists at `soft-sme-backend/apt.txt` so Render installs `tesseract-ocr`, `tesseract-ocr-eng`, and `poppler-utils`
 
 ### Database Connection Issues
 - Verify database environment variables are set correctly

--- a/soft-sme-backend/render-build.sh
+++ b/soft-sme-backend/render-build.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure required OCR system packages are installed. Render's Node environment
-# is Debian-based, so we can use apt-get when the binaries are missing.
-if ! command -v tesseract >/dev/null 2>&1; then
-  echo "Installing Tesseract OCR dependencies via apt-get..."
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    tesseract-ocr \
-    tesseract-ocr-eng \
-    poppler-utils
-  rm -rf /var/lib/apt/lists/*
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APT_FILE="${SCRIPT_DIR}/apt.txt"
+
+if [[ -f "${APT_FILE}" ]]; then
+  echo "Found apt.txt at soft-sme-backend/apt.txt; Render installs these packages before running the build command."
 else
-  echo "Tesseract OCR already available; skipping apt-get install."
+  echo "WARN: soft-sme-backend/apt.txt is missing. Render will not preinstall Tesseract/Poppler without it."
 fi
 
-npm install --include=dev
+if command -v tesseract >/dev/null 2>&1; then
+  echo "Tesseract available at $(command -v tesseract)"
+else
+  echo "WARN: tesseract not in PATH yet (Render should provision it from apt.txt before the app starts)."
+fi
+
+npm ci
 npm run build

--- a/soft-sme-backend/render.yaml
+++ b/soft-sme-backend/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: web
     name: soft-sme-backend
     env: node
+    rootDir: soft-sme-backend
     buildCommand: ./render-build.sh
     startCommand: npm start
     envVars:
@@ -37,4 +38,4 @@ services:
 databases:
   - name: soft-sme-db
     databaseName: soft_sme_db
-    user: soft_sme_user 
+    user: soft_sme_user


### PR DESCRIPTION
## Summary
- set the Render blueprint to use soft-sme-backend as the service root so apt.txt is detected
- simplify render-build.sh to log dependency status and run the Node build without attempting apt installs
- update deployment docs to reflect the corrected root directory and build script behavior

## Testing
- bash -n soft-sme-backend/render-build.sh

------
https://chatgpt.com/codex/tasks/task_e_68e47a275a588324861f59687ee88191