### PR TITLE
Fix ChatMessage avatar markup

### DIFF
--- a/soft-sme-frontend/src/components/ChatMessage.tsx
+++ b/soft-sme-frontend/src/components/ChatMessage.tsx
@@ -106,8 +106,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
         </Typography>
       </Paper>
 
-        <Paper
-          elevation={0}
+      {isUser && (
+        <Avatar
           sx={{
             bgcolor: 'secondary.main',
             width: 34,


### PR DESCRIPTION
## Summary
- fix the ChatMessage JSX structure so the user avatar renders with the correct component
- resolve the mismatched closing tags that broke the frontend build

## Testing
- npx tsc --pretty false
- CI=1 NO_COLOR=1 npx vite build --logLevel info

------
https://chatgpt.com/codex/tasks/task_e_68e48a4f0ec483249205b7820c4e440f