### PR TITLE
Refine messaging layout and copilot access

### DIFF
--- a/soft-sme-frontend/src/App.tsx
+++ b/soft-sme-frontend/src/App.tsx
@@ -68,11 +68,17 @@ const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => 
       return <Navigate to="/attendance" replace />;
     }
     // Only allow /time-tracking, /attendance, /open-sales-orders, and /woker-sales-orders
-    if (path !== '/time-tracking' && path !== '/attendance' && !path.startsWith('/open-sales-orders') && !path.startsWith('/woker-sales-orders')) {
+    if (
+      path !== '/time-tracking' &&
+      path !== '/attendance' &&
+      path !== '/messaging' &&
+      !path.startsWith('/open-sales-orders') &&
+      !path.startsWith('/woker-sales-orders')
+    ) {
       return <Navigate to="/attendance" replace />;
     }
   }
-  
+
   if (user?.access_role === 'Sales and Purchase') {
     const allowed = [
       '/',
@@ -84,6 +90,7 @@ const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => 
       '/supply',
       '/email-settings',
       '/tasks',
+      '/messaging',
     ];
     // Allow paths that start with /open-sales-orders/, /open-purchase-orders/, /purchase-order/ (for detail pages)
     if (
@@ -99,7 +106,7 @@ const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   // (No restriction block for Admin)
   if (user?.access_role === 'Quotes') {
     // Allow list and editor/detail routes under /quotes
-    if (path !== '/quotes' && !path.startsWith('/quotes/')) {
+    if (path !== '/quotes' && !path.startsWith('/quotes/') && path !== '/messaging') {
       return <Navigate to="/quotes" replace />;
     }
   }

--- a/soft-sme-frontend/src/components/ChatBubble.tsx
+++ b/soft-sme-frontend/src/components/ChatBubble.tsx
@@ -11,22 +11,33 @@ interface ChatBubbleProps {
 const ChatBubble: React.FC<ChatBubbleProps> = ({ onClick, isOpen, unreadCount = 0 }) => {
   return (
     <Fab
-      color="primary"
-      aria-label="chat"
+      aria-label="Workspace Copilot"
       onClick={onClick}
       sx={{
         position: 'fixed',
-        bottom: 24,
-        right: 24,
-        zIndex: 1000,
-        boxShadow: 3,
+        bottom: { xs: 16, sm: 24 },
+        right: { xs: 16, sm: 24 },
+        zIndex: 1300,
+        bgcolor: (theme) => theme.palette.background.paper,
+        color: (theme) => theme.palette.primary.main,
+        boxShadow: '0 18px 40px rgba(33, 150, 243, 0.25)',
+        border: '1px solid',
+        borderColor: (theme) => theme.palette.divider,
+        transition: 'transform 0.2s ease, box-shadow 0.2s ease',
         '&:hover': {
-          transform: 'scale(1.1)',
-          transition: 'transform 0.2s ease-in-out',
+          transform: 'translateY(-3px)',
+          boxShadow: '0 22px 48px rgba(33, 150, 243, 0.32)',
+          bgcolor: (theme) => theme.palette.primary.main,
+          color: 'common.white',
         },
       }}
     >
-      <Badge badgeContent={unreadCount} color="error" invisible={unreadCount === 0}>
+      <Badge
+        color="error"
+        badgeContent={unreadCount}
+        invisible={unreadCount === 0}
+        sx={{ '& .MuiBadge-badge': { fontWeight: 600 } }}
+      >
         <ChatIcon />
       </Badge>
     </Fab>

--- a/soft-sme-frontend/src/components/ChatWindow.tsx
+++ b/soft-sme-frontend/src/components/ChatWindow.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Divider,
   CircularProgress,
-  Chip,
   Avatar,
   Tooltip,
   Paper,
@@ -62,53 +61,38 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
     width: '100%',
     display: 'flex',
     flexDirection: 'column',
-    borderRadius: isEmbedded ? 4 : 0,
+    borderRadius: isEmbedded ? 3 : 0,
     overflow: 'hidden',
     bgcolor: 'background.paper',
-    boxShadow: isEmbedded ? '0 20px 50px -28px rgba(15, 23, 42, 0.32)' : 'none',
-    border: isEmbedded ? '1px solid' : 'none',
+    boxShadow: isEmbedded ? '0 12px 32px rgba(15, 23, 42, 0.16)' : 'none',
+    border: '1px solid',
     borderColor: isEmbedded ? 'divider' : 'transparent',
-    minHeight: isEmbedded ? { xs: 360, md: 420 } : 'auto',
+    minHeight: isEmbedded ? { xs: 320, md: 380 } : 'auto',
     maxHeight: isEmbedded ? { xs: '60vh', md: 520 } : 'none',
   };
 
   const headerStyles: SxProps<Theme> = {
     px: { xs: 2.5, sm: 3 },
-    py: 2.5,
+    py: 2.25,
     display: 'flex',
     alignItems: { xs: 'flex-start', sm: 'center' },
     flexDirection: { xs: 'column', sm: 'row' },
     gap: { xs: 2, sm: 3 },
     justifyContent: 'space-between',
-    position: 'relative',
     borderBottom: '1px solid',
     borderColor: 'divider',
-    backgroundImage: isEmbedded
-      ? 'linear-gradient(135deg, rgba(123, 104, 238, 0.12) 0%, rgba(33, 150, 243, 0.08) 50%, rgba(0, 200, 140, 0.12) 100%)'
-      : undefined,
-    backgroundColor: isEmbedded ? 'rgba(255,255,255,0.85)' : 'transparent',
-    '&::after': !isEmbedded
-      ? {
-          content: "''",
-          position: 'absolute',
-          inset: 0,
-          background:
-            'linear-gradient(135deg, rgba(123, 104, 238, 0.12) 0%, rgba(33, 150, 243, 0.08) 50%, rgba(0, 200, 140, 0.12) 100%)',
-          opacity: 0.6,
-          zIndex: -1,
-        }
-      : undefined,
+    backgroundColor: (theme) => (isEmbedded ? theme.palette.background.paper : theme.palette.background.default),
   };
 
   const messagesWrapperStyles: SxProps<Theme> = {
     flex: 1,
     overflow: 'auto',
-    px: { xs: 2.25, sm: 3.25 },
-    py: 3,
+    px: { xs: 2.25, sm: 3 },
+    py: 2.5,
     display: 'flex',
     flexDirection: 'column',
-    gap: 2.5,
-    backgroundImage: 'linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(247, 250, 255, 0.85) 100%)',
+    gap: 2,
+    backgroundColor: (theme) => theme.palette.background.default,
   };
 
   const WrapperComponent: React.ElementType = isEmbedded ? Paper : Box;
@@ -120,23 +104,21 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
           <Avatar
             sx={{
               bgcolor: 'primary.main',
-              width: 56,
-              height: 56,
-              boxShadow: '0 10px 30px rgba(64, 132, 253, 0.35)',
+              color: 'common.white',
+              width: 48,
+              height: 48,
+              boxShadow: '0 10px 24px rgba(33, 150, 243, 0.28)',
             }}
           >
-            <SmartToyIcon fontSize="medium" />
+            <SmartToyIcon fontSize="small" />
           </Avatar>
           <Box>
-            <Typography variant="h6" sx={{ fontWeight: 800, letterSpacing: -0.2 }}>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
               Workspace Copilot
             </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, flexWrap: 'wrap' }}>
-              <Chip size="small" label="Live" color="success" sx={{ fontWeight: 700, px: 0.75, borderRadius: '999px' }} />
-              <Typography variant="body2" color="text.secondary">
-                Instantly summarise, draft, and explore your data
-              </Typography>
-            </Box>
+            <Typography variant="body2" color="text.secondary">
+              Ask about anything in your workspace for instant help.
+            </Typography>
           </Box>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
@@ -145,13 +127,10 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
               onClick={handleScrollToLatest}
               size="small"
               sx={{
-                bgcolor: 'common.white',
+                bgcolor: 'background.paper',
                 border: '1px solid',
                 borderColor: 'divider',
-                boxShadow: '0 8px 18px rgba(15, 23, 42, 0.08)',
-                '&:hover': {
-                  bgcolor: 'grey.50',
-                },
+                '&:hover': { bgcolor: 'grey.50' },
               }}
             >
               <KeyboardDoubleArrowDownIcon fontSize="small" />
@@ -166,7 +145,7 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
                 textTransform: 'none',
                 fontWeight: 600,
                 px: 1.75,
-                borderRadius: '999px',
+                borderRadius: 999,
                 borderColor: 'divider',
               }}
             >
@@ -179,12 +158,10 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
                 onClick={onClose}
                 size="small"
                 sx={{
-                  bgcolor: 'common.white',
+                  bgcolor: 'background.paper',
                   border: '1px solid',
                   borderColor: 'divider',
-                  '&:hover': {
-                    bgcolor: 'grey.50',
-                  },
+                  '&:hover': { bgcolor: 'grey.50' },
                 }}
               >
                 <CloseIcon fontSize="small" />
@@ -196,33 +173,32 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
 
       <Box sx={messagesWrapperStyles}>
         {messages.length === 0 ? (
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-              textAlign: 'center',
-              color: 'text.secondary',
-              gap: 1.5,
-              backgroundColor: 'common.white',
-              borderRadius: 4,
-              border: '1px solid',
-              borderColor: 'divider',
-              boxShadow: '0 18px 45px -24px rgba(15, 23, 42, 0.18)',
-              mx: 'auto',
-              p: 4,
-              maxWidth: 340,
-            }}
-          >
-            <Typography variant="h6" sx={{ fontWeight: 700 }}>
-              Start a fresh conversation
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-              Ask about inventory, customers, orders, or time tracking. I will keep every reply crisp and actionable.
-            </Typography>
-          </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+                textAlign: 'center',
+                color: 'text.secondary',
+                gap: 1.5,
+                borderRadius: 3,
+                border: '1px dashed',
+                borderColor: 'divider',
+                mx: 'auto',
+                p: 4,
+                maxWidth: 320,
+                bgcolor: 'background.paper',
+              }}
+            >
+              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                Start a fresh conversation
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                Ask about inventory, customers, orders, or time tracking.
+              </Typography>
+            </Box>
         ) : (
           <>
             {messages.map((message) => (
@@ -230,25 +206,18 @@ export const ChatBoard: React.FC<ChatBoardProps> = ({ variant = 'drawer', onClos
             ))}
 
             {isLoading && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'flex-start',
-                  mb: 1,
-                }}
-              >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.25,
+                <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: 1 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                    px: 2,
                     py: 1.25,
-                    bgcolor: 'common.white',
-                    borderRadius: 3,
+                    bgcolor: 'background.paper',
+                    borderRadius: 2,
                     border: '1px solid',
                     borderColor: 'divider',
-                    boxShadow: '0 14px 36px -28px rgba(15, 23, 42, 0.4)',
                   }}
                 >
                   <CircularProgress size={16} thickness={5} />
@@ -283,17 +252,14 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isOpen, onClose }) => {
       onClose={onClose}
       sx={{
         '& .MuiDrawer-paper': {
-          width: { xs: '100%', sm: 420, md: 500 },
+          width: { xs: '100%', sm: 400, md: 460 },
           maxWidth: '100vw',
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
           borderLeft: { sm: '1px solid', xs: 'none' },
           borderColor: 'divider',
-          bgcolor: 'transparent',
-          backgroundImage:
-            'radial-gradient(circle at top left, rgba(64, 132, 253, 0.16), transparent 55%), linear-gradient(180deg, #f7f9fc 0%, #ffffff 35%, #f7f9fc 100%)',
-          backdropFilter: 'blur(12px)',
+          bgcolor: 'background.default',
         },
       }}
     >

--- a/soft-sme-frontend/src/components/ConversationList.tsx
+++ b/soft-sme-frontend/src/components/ConversationList.tsx
@@ -23,6 +23,7 @@ interface ConversationListProps {
   onSelect: (conversationId: number) => void;
   onStartConversation: () => void;
   isLoading?: boolean;
+  unreadConversationIds?: number[];
 }
 
 const ConversationList: React.FC<ConversationListProps> = ({
@@ -31,8 +32,11 @@ const ConversationList: React.FC<ConversationListProps> = ({
   onSelect,
   onStartConversation,
   isLoading = false,
+  unreadConversationIds,
 }) => {
   const [query, setQuery] = useState('');
+
+  const unreadIds = useMemo(() => new Set(unreadConversationIds ?? []), [unreadConversationIds]);
 
   const filteredConversations = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
@@ -90,6 +94,7 @@ const ConversationList: React.FC<ConversationListProps> = ({
               const lastMessage = conversation.lastMessage?.content;
               const lastTimestamp = conversation.lastMessageAt || conversation.updatedAt || conversation.createdAt;
               const timeAgo = formatDistanceToNowStrict(new Date(lastTimestamp), { addSuffix: true });
+              const isUnread = unreadIds.has(conversation.id);
 
               return (
                 <React.Fragment key={conversation.id}>
@@ -102,6 +107,7 @@ const ConversationList: React.FC<ConversationListProps> = ({
                       '&.Mui-selected': {
                         backgroundColor: 'action.selected',
                       },
+                      bgcolor: isUnread ? 'action.hover' : undefined,
                       '& .MuiListItemText-secondary': {
                         display: '-webkit-box',
                         overflow: 'hidden',
@@ -118,14 +124,28 @@ const ConversationList: React.FC<ConversationListProps> = ({
                     <ListItemText
                       primary={
                         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
-                          <Typography variant="subtitle1" noWrap>
+                          <Typography variant="subtitle1" noWrap sx={{ fontWeight: isUnread ? 600 : 500 }}>
                             {conversation.displayName}
                           </Typography>
-                          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-                            {timeAgo}
-                          </Typography>
+                          <Stack direction="row" alignItems="center" spacing={1.25} sx={{ flexShrink: 0 }}>
+                            {isUnread && (
+                              <Box
+                                component="span"
+                                sx={{
+                                  width: 8,
+                                  height: 8,
+                                  borderRadius: '50%',
+                                  bgcolor: 'primary.main',
+                                }}
+                              />
+                            )}
+                            <Typography variant="caption" color="text.secondary">
+                              {timeAgo}
+                            </Typography>
+                          </Stack>
                         </Stack>
                       }
+                      secondaryTypographyProps={{ fontWeight: isUnread ? 600 : undefined }}
                       secondary={lastMessage || 'No messages yet'}
                     />
                   </ListItemButton>

--- a/soft-sme-frontend/src/components/Layout.tsx
+++ b/soft-sme-frontend/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { useNavigate, Outlet, useLocation } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 import {
   AppBar,
   Box,
+  Badge,
   Button,
   Drawer,
   IconButton,
@@ -44,20 +45,20 @@ import { useAuth } from '../contexts/AuthContext';
 import ChatBubble from './ChatBubble';
 import ChatWindow from './ChatWindow';
 import { useChat } from '../hooks/useChat';
-import { Alert, Tooltip } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { Tooltip } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
 import { getPendingCount, syncPending } from '../services/offlineSync';
+import { useMessaging } from '../contexts/MessagingContext';
 
 const drawerWidth = 240;
 
 const Layout: React.FC = () => {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const navigate = useNavigate();
-  const location = useLocation();
   const { logout, user } = useAuth();
   const { isOpen, toggleChat, closeChat, unreadCount } = useChat();
+  const { unreadConversationCount } = useMessaging();
   const [pendingCount, setPendingCount] = useState<number>(0);
-  const isMessagingEmbedded = location.pathname === '/' || location.pathname === '/dashboard';
 
   useEffect(() => {
     let mounted = true;
@@ -81,110 +82,143 @@ const Layout: React.FC = () => {
     navigate('/login');
   };
 
-  const menuItems = [
-    { type: 'header', text: 'Dashboard' },
-    { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
-    { text: 'Tasks', icon: <AssignmentTurnedInIcon />, path: '/tasks' },
+  type HeaderMenuEntry = { type: 'header'; text: string };
+  type NavigationMenuEntry = { text: string; icon: React.ReactNode; path: string; showUnreadDot?: boolean };
+  type MenuEntry = HeaderMenuEntry | NavigationMenuEntry;
 
-    { type: 'header', text: 'Purchasing' },
-    { text: 'Purchase Orders', icon: <AssignmentIcon />, path: '/open-purchase-orders' },
-    { text: 'Parts to Order', icon: <InventoryIcon />, path: '/parts-to-order' },
-    { text: 'Vendors', icon: <StoreIcon />, path: '/vendors' },
+  const isHeaderItem = (entry: MenuEntry): entry is HeaderMenuEntry =>
+    'type' in entry && entry.type === 'header';
 
-    { type: 'header', text: 'Sales' },
-    { text: 'Quotes', icon: <ListAltIcon />, path: '/quotes' },
-    { text: 'Sales Orders', icon: <ReceiptIcon />, path: '/open-sales-orders' },
-    { text: 'Customers', icon: <PeopleIcon />, path: '/customers' },
+  const messageMenuItem = useMemo<MenuEntry>(
+    () => ({
+      text: 'Messages',
+      icon: <ChatIcon />,
+      path: '/messaging',
+      showUnreadDot: unreadConversationCount > 0,
+    }),
+    [unreadConversationCount]
+  );
 
-    { type: 'header', text: 'Products & Inventory' },
-    { text: 'Products', icon: <LocalOfferIcon />, path: '/products' },
-    { text: 'Stock', icon: <InventoryIcon />, path: '/inventory' },
-    { text: 'Supply', icon: <InventoryIcon />, path: '/supply' },
+  const menuItems = useMemo<MenuEntry[]>(
+    () => [
+      { type: 'header', text: 'Dashboard' },
+      { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
+      { text: 'Tasks', icon: <AssignmentTurnedInIcon />, path: '/tasks' },
+      messageMenuItem,
 
-    { type: 'header', text: 'Time Tracking' },
-    { text: 'Attendance', icon: <TimelineIcon />, path: '/attendance' },
-    { text: 'Time Tracking', icon: <TimelineIcon />, path: '/time-tracking' },
-    { text: 'Time Tracking Reports', icon: <QueryStatsIcon />, path: '/time-tracking/reports' },
+      { type: 'header', text: 'Purchasing' },
+      { text: 'Purchase Orders', icon: <AssignmentIcon />, path: '/open-purchase-orders' },
+      { text: 'Parts to Order', icon: <InventoryIcon />, path: '/parts-to-order' },
+      { text: 'Vendors', icon: <StoreIcon />, path: '/vendors' },
 
-    { type: 'header', text: 'Human Resources' },
-    { text: 'Employees', icon: <GroupIcon />, path: '/employees' },
-    { text: 'Profile Documents', icon: <DescriptionIcon />, path: '/profile-documents' },
-    { text: 'Leave Management', icon: <CalendarIcon />, path: '/leave-management' },
-    { text: 'Mobile User Access', icon: <PeopleIcon />, path: '/mobile-user-access' },
+      { type: 'header', text: 'Sales' },
+      { text: 'Quotes', icon: <ListAltIcon />, path: '/quotes' },
+      { text: 'Sales Orders', icon: <ReceiptIcon />, path: '/open-sales-orders' },
+      { text: 'Customers', icon: <PeopleIcon />, path: '/customers' },
 
-    { type: 'header', text: 'Communication' },
-    { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
+      { type: 'header', text: 'Products & Inventory' },
+      { text: 'Products', icon: <LocalOfferIcon />, path: '/products' },
+      { text: 'Stock', icon: <InventoryIcon />, path: '/inventory' },
+      { text: 'Supply', icon: <InventoryIcon />, path: '/supply' },
 
-    { type: 'header', text: 'Settings' },
-    { text: 'Business Profile', icon: <BusinessIcon />, path: '/business-profile' },
-    { text: 'Accounting', icon: <AttachMoneyIcon />, path: '/qbo-account-mapping' },
-    { text: 'Global Variables', icon: <AttachMoneyIcon />, path: '/margin-schedule' },
-    { text: 'Email Settings', icon: <EmailIcon />, path: '/email-settings' },
-    { text: 'Backup Management', icon: <BackupIcon />, path: '/backup-management' },
-  ];
+      { type: 'header', text: 'Time Tracking' },
+      { text: 'Attendance', icon: <TimelineIcon />, path: '/attendance' },
+      { text: 'Time Tracking', icon: <TimelineIcon />, path: '/time-tracking' },
+      { text: 'Time Tracking Reports', icon: <QueryStatsIcon />, path: '/time-tracking/reports' },
+
+      { type: 'header', text: 'Human Resources' },
+      { text: 'Employees', icon: <GroupIcon />, path: '/employees' },
+      { text: 'Profile Documents', icon: <DescriptionIcon />, path: '/profile-documents' },
+      { text: 'Leave Management', icon: <CalendarIcon />, path: '/leave-management' },
+      { text: 'Mobile User Access', icon: <PeopleIcon />, path: '/mobile-user-access' },
+
+      { type: 'header', text: 'Settings' },
+      { text: 'Business Profile', icon: <BusinessIcon />, path: '/business-profile' },
+      { text: 'Accounting', icon: <AttachMoneyIcon />, path: '/qbo-account-mapping' },
+      { text: 'Global Variables', icon: <AttachMoneyIcon />, path: '/margin-schedule' },
+      { text: 'Email Settings', icon: <EmailIcon />, path: '/email-settings' },
+      { text: 'Backup Management', icon: <BackupIcon />, path: '/backup-management' },
+    ],
+    [messageMenuItem]
+  );
 
   // Filter menu items for Time Tracking users
-  const filteredMenuItems = React.useMemo(() => {
+  const filteredMenuItems = React.useMemo<MenuEntry[]>(() => {
     if (user?.access_role === 'Time Tracking') {
       return [
-        { type: 'header', text: 'Time Tracking' },
+        { type: 'header', text: 'Dashboard' },
         { text: 'Attendance', icon: <TimelineIcon />, path: '/attendance' },
         { text: 'Time Tracking', icon: <TimelineIcon />, path: '/time-tracking' },
-        { type: 'header', text: 'Human Resources' },
-        { text: 'Leave Management', icon: <CalendarIcon />, path: '/leave-management' },
-        { type: 'header', text: 'Communication' },
-        { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
+        messageMenuItem,
         { type: 'header', text: 'Sales' },
         { text: 'Sales Orders', icon: <ReceiptIcon />, path: '/open-sales-orders' },
       ];
     }
     // Always show Dashboard at the top as a separate section
-    const dashboardSection = [
+    const dashboardSection: MenuEntry[] = [
       { type: 'header', text: 'Main' },
       { text: 'Dashboard', icon: <DashboardIcon />, path: '/' },
+      { text: 'Tasks', icon: <AssignmentTurnedInIcon />, path: '/tasks' },
+      messageMenuItem,
     ];
     if (user?.access_role === 'Sales and Purchase') {
       return [
         ...dashboardSection,
         { type: 'header', text: 'Sales & Purchase' },
-        { text: 'Tasks', icon: <AssignmentTurnedInIcon />, path: '/tasks' },
         { text: 'Sales Orders', icon: <ReceiptIcon />, path: '/open-sales-orders' },
         { text: 'Purchase Orders', icon: <AssignmentIcon />, path: '/open-purchase-orders' },
         { text: 'Parts to Order', icon: <InventoryIcon />, path: '/parts-to-order' },
         { type: 'header', text: 'Inventory' },
         { text: 'Stock', icon: <InventoryIcon />, path: '/inventory' },
         { text: 'Supply', icon: <InventoryIcon />, path: '/supply' },
-        { type: 'header', text: 'Communication' },
-        { text: 'Messaging', icon: <ChatIcon />, path: '/messaging' },
         { type: 'header', text: 'Settings' },
         { text: 'Email Settings', icon: <EmailIcon />, path: '/email-settings' },
       ];
     }
     return menuItems;
-  }, [user, menuItems]);
+  }, [user, menuItems, messageMenuItem]);
 
   const drawer = (
     <div>
       <Toolbar />
       <List>
-        {filteredMenuItems.map((item, idx) =>
-          item.type === 'header' ? (
-            <ListSubheader key={`header-${item.text}-${idx}`} sx={{ bgcolor: 'inherit', color: 'text.secondary', fontWeight: 'bold', fontSize: 13, textAlign: 'left', pl: 2 }}>
-              {item.text}
-            </ListSubheader>
-          ) : (
-          <ListItem
-            key={item.path || `${item.text}-${idx}`}
-            onClick={() => {
-              navigate(item.path);
-              setMobileOpen(false);
-            }}
-            sx={{ cursor: 'pointer' }}
-          >
-            <ListItemIcon>{item.icon}</ListItemIcon>
-            <ListItemText primary={item.text} />
-          </ListItem>
-        ))}
+        {filteredMenuItems.map((item, idx) => {
+          if (isHeaderItem(item)) {
+            return (
+              <ListSubheader
+                key={`header-${item.text}-${idx}`}
+                sx={{ bgcolor: 'inherit', color: 'text.secondary', fontWeight: 'bold', fontSize: 13, textAlign: 'left', pl: 2 }}
+              >
+                {item.text}
+              </ListSubheader>
+            );
+          }
+          const navItem = item as NavigationMenuEntry;
+          return (
+            <ListItem
+              key={navItem.path || `${navItem.text}-${idx}`}
+              onClick={() => {
+                navigate(navItem.path);
+                setMobileOpen(false);
+              }}
+              sx={{ cursor: 'pointer' }}
+            >
+              <ListItemIcon>
+                {navItem.showUnreadDot ? (
+                  <Badge color="error" variant="dot" overlap="circular">
+                    {navItem.icon}
+                  </Badge>
+                ) : (
+                  navItem.icon
+                )}
+              </ListItemIcon>
+              <ListItemText
+                primary={navItem.text}
+                primaryTypographyProps={navItem.showUnreadDot ? { fontWeight: 600 } : undefined}
+              />
+            </ListItem>
+          );
+        })}
       </List>
     </div>
   );
@@ -268,12 +302,8 @@ const Layout: React.FC = () => {
       </Box>
       
       {/* Chat Components */}
-      {!isMessagingEmbedded && (
-        <>
-          <ChatBubble onClick={toggleChat} isOpen={isOpen} unreadCount={unreadCount} />
-          <ChatWindow isOpen={isOpen} onClose={closeChat} />
-        </>
-      )}
+      <ChatBubble onClick={toggleChat} isOpen={isOpen} unreadCount={unreadCount} />
+      <ChatWindow isOpen={isOpen} onClose={closeChat} />
     </Box>
   );
 };

--- a/soft-sme-frontend/src/pages/LandingPage.tsx
+++ b/soft-sme-frontend/src/pages/LandingPage.tsx
@@ -11,6 +11,8 @@ import {
   Box,
   Divider,
   Avatar,
+  Paper,
+  Stack,
   useTheme,
   Fade
 } from "@mui/material";
@@ -37,7 +39,7 @@ import { useAuth } from '../contexts/AuthContext';
 import TaskSummaryWidget from '../components/tasks/TaskSummaryWidget';
 import { getTaskSummary } from '../services/taskService';
 import { TaskSummary } from '../types/task';
-import { ChatBoard } from '../components/ChatWindow';
+import { SmartToy as SmartToyIcon } from '@mui/icons-material';
 
 const sectionIcons: Record<string, React.ReactNode> = {
   'Purchasing': <AssignmentIcon sx={{ color: 'primary.main' }} />,
@@ -197,15 +199,32 @@ const LandingPage: React.FC = () => {
         />
       </Box>
 
-      <Box sx={{ mb: 6 }}>
-        <Typography variant="h4" component="h2" sx={{ mb: 2, fontWeight: 600 }}>
-          Workspace Copilot
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Get instant answers, summaries, and suggestions tailored to your current data without leaving the dashboard.
-        </Typography>
-        <ChatBoard variant="embedded" sx={{ maxWidth: '100%' }} />
-      </Box>
+      <Paper
+        elevation={0}
+        sx={{
+          mb: 6,
+          px: { xs: 3, md: 4 },
+          py: { xs: 3, md: 4 },
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} alignItems="center">
+          <Avatar sx={{ bgcolor: 'primary.main', width: 56, height: 56 }}>
+            <SmartToyIcon fontSize="medium" />
+          </Avatar>
+          <Box sx={{ textAlign: { xs: 'center', sm: 'left' } }}>
+            <Typography variant="h5" component="h2" sx={{ fontWeight: 600 }}>
+              Workspace Copilot
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Need a hand? Click the Copilot bubble in the lower-right corner to open the AI assistant without leaving your work.
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
 
       {filteredSections.map((section, sectionIndex) => (
         <Fade in timeout={700 + sectionIndex * 200} key={section.title}>

--- a/soft-sme-frontend/src/pages/MessagingPage.tsx
+++ b/soft-sme-frontend/src/pages/MessagingPage.tsx
@@ -7,7 +7,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Grid,
+  Divider,
   Paper,
   Stack,
   TextField,
@@ -42,6 +42,7 @@ const MessagingPage: React.FC = () => {
     createConversation,
     loadMessages,
     deleteMessage,
+    unreadConversationIds,
   } = useMessaging();
 
   const [employees, setEmployees] = useState<EmployeeOption[]>([]);
@@ -185,8 +186,8 @@ const MessagingPage: React.FC = () => {
   const autocompleteOptions = useMemo(() => employees, [employees]);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: { xs: 2, md: 3 } }}>
-      <Stack spacing={1} sx={{ mb: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', p: { xs: 2, md: 3 }, gap: 3 }}>
+      <Stack spacing={1}>
         <Typography variant="h4" component="h1">
           Messaging
         </Typography>
@@ -195,32 +196,55 @@ const MessagingPage: React.FC = () => {
         </Typography>
       </Stack>
 
-      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
-        <Grid container spacing={2} sx={{ height: '100%' }}>
-          <Grid item xs={12} md={4} sx={{ height: { xs: 'auto', md: '100%' } }}>
-            <Paper sx={{ height: { xs: 'auto', md: '100%' }, p: 2, display: 'flex', flexDirection: 'column' }}>
-              <ConversationList
-                conversations={conversations}
-                activeConversationId={activeConversationId}
-                onSelect={selectConversation}
-                onStartConversation={handleStartConversation}
-                isLoading={isLoadingConversations}
-              />
-            </Paper>
-          </Grid>
-          <Grid item xs={12} md={8} sx={{ height: { xs: '60vh', md: '100%' } }}>
-            <MessageThread
-              conversation={activeConversation}
-              messages={activeMessages}
-              currentUserId={currentUserId}
-              isLoading={messagesLoading}
-              isSending={isSending}
-              onSendMessage={handleSendMessage}
-              onDeleteMessage={handleDeleteMessage}
+      <Paper
+        elevation={0}
+        sx={{
+          flexGrow: 1,
+          minHeight: { xs: 480, md: 540 },
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          borderRadius: 3,
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <Box
+          sx={{
+            width: { xs: '100%', md: 340 },
+            flexShrink: 0,
+            borderRight: { md: '1px solid', xs: 'none' },
+            borderColor: 'divider',
+            backgroundColor: 'background.default',
+          }}
+        >
+          <Box sx={{ height: '100%', p: { xs: 2, md: 2.5 } }}>
+            <ConversationList
+              conversations={conversations}
+              activeConversationId={activeConversationId}
+              onSelect={selectConversation}
+              onStartConversation={handleStartConversation}
+              isLoading={isLoadingConversations}
+              unreadConversationIds={unreadConversationIds}
             />
-          </Grid>
-        </Grid>
-      </Box>
+          </Box>
+        </Box>
+
+        <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+
+        <Box sx={{ flex: 1, p: { xs: 2, md: 2.5 }, display: 'flex', flexDirection: 'column', backgroundColor: 'background.paper' }}>
+          <MessageThread
+            conversation={activeConversation}
+            messages={activeMessages}
+            currentUserId={currentUserId}
+            isLoading={messagesLoading}
+            isSending={isSending}
+            onSendMessage={handleSendMessage}
+            onDeleteMessage={handleDeleteMessage}
+          />
+        </Box>
+      </Paper>
 
       <Dialog open={dialogOpen} onClose={handleCloseDialog} fullWidth maxWidth="sm">
         <DialogTitle>Start a Conversation</DialogTitle>


### PR DESCRIPTION
## Summary
- restore the Copilot bubble UI and simplify the chat drawer styling
- move the Messages navigation entry under the dashboard with unread indicators
- refresh the employee messaging experience and track unread threads in context

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e48da27af88324802eac8f801b9cb8