### PR TITLE
Improve OCR binary discovery in Render environments

### DIFF
--- a/soft-sme-backend/src/services/PurchaseOrderOcrService.ts
+++ b/soft-sme-backend/src/services/PurchaseOrderOcrService.ts
@@ -71,8 +71,52 @@ export class PurchaseOrderOcrService {
 
   constructor(uploadDir: string, options: PurchaseOrderOcrServiceOptions = {}) {
     this.uploadDir = uploadDir;
-    this.tesseractCmd = options.tesseractCmd || process.env.TESSERACT_CMD || 'tesseract';
-    this.pdftoppmCmd = options.pdftoppmCmd || process.env.PDFTOPPM_CMD || 'pdftoppm';
+
+    this.augmentProcessPath([
+      '/opt/render/project/.apt/usr/bin',
+      '/opt/render/project/src/.apt/usr/bin',
+      '/opt/render/.apt/usr/bin',
+    ]);
+
+    const preferredTesseract = options.tesseractCmd || process.env.TESSERACT_CMD || 'tesseract';
+    const resolvedTesseract = this.resolveCommand(preferredTesseract, [
+      preferredTesseract,
+      '/opt/render/project/.apt/usr/bin/tesseract',
+      '/opt/render/project/src/.apt/usr/bin/tesseract',
+      '/opt/render/.apt/usr/bin/tesseract',
+      '/usr/bin/tesseract',
+      '/usr/local/bin/tesseract',
+    ]);
+
+    if (resolvedTesseract) {
+      this.tesseractCmd = resolvedTesseract;
+    } else {
+      this.tesseractCmd = preferredTesseract;
+      console.warn(
+        'PurchaseOrderOcrService: Tesseract command not found in PATH or fallback locations. '
+          + 'OCR requests will fail until it is installed.'
+      );
+    }
+
+    const preferredPdftoppm = options.pdftoppmCmd || process.env.PDFTOPPM_CMD || 'pdftoppm';
+    const resolvedPdftoppm = this.resolveCommand(preferredPdftoppm, [
+      preferredPdftoppm,
+      '/opt/render/project/.apt/usr/bin/pdftoppm',
+      '/opt/render/project/src/.apt/usr/bin/pdftoppm',
+      '/opt/render/.apt/usr/bin/pdftoppm',
+      '/usr/bin/pdftoppm',
+      '/usr/local/bin/pdftoppm',
+    ]);
+
+    if (resolvedPdftoppm) {
+      this.pdftoppmCmd = resolvedPdftoppm;
+    } else {
+      this.pdftoppmCmd = preferredPdftoppm;
+      console.warn(
+        'PurchaseOrderOcrService: pdftoppm command not found in PATH or fallback locations. '
+          + 'PDF OCR conversion will be unavailable until it is installed.'
+      );
+    }
   }
 
   async processDocument(file: Express.Multer.File): Promise<PurchaseOrderOcrResponse> {
@@ -189,7 +233,7 @@ export class PurchaseOrderOcrService {
     } catch (error: any) {
       if (error?.code === 'ENOENT') {
         throw new Error(
-          'Tesseract binary not found. Install tesseract-ocr (apk add tesseract-ocr tesseract-ocr-data-eng or apt-get install tesseract-ocr tesseract-ocr-eng) on the server and ensure it is available in PATH.'
+          `Tesseract binary not found at "${this.tesseractCmd}". Install tesseract-ocr (apk add tesseract-ocr tesseract-ocr-data-eng or apt-get install tesseract-ocr tesseract-ocr-eng) on the server and ensure it is available in PATH.`
         );
       }
       if (error?.stderr) {
@@ -547,5 +591,110 @@ export class PurchaseOrderOcrService {
       fs.promises.writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8'),
       fs.promises.writeFile(textPath, result.ocr.rawText, 'utf-8'),
     ]);
+  }
+
+  private resolveCommand(preferred: string, fallbacks: string[]): string | null {
+    const candidates = this.normalizeCommandCandidates(preferred, fallbacks);
+
+    for (const candidate of candidates) {
+      const resolved = this.isExplicitPath(candidate)
+        ? this.checkExplicitPath(candidate)
+        : this.findInSystemPath(candidate);
+
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return null;
+  }
+
+  private augmentProcessPath(candidates: string[]): void {
+    const currentPath = process.env.PATH || '';
+    const segments = currentPath.split(path.delimiter).filter((segment) => segment.length > 0);
+
+    for (const candidate of candidates) {
+      if (!candidate) {
+        continue;
+      }
+
+      let stats: fs.Stats | null = null;
+      try {
+        stats = fs.statSync(candidate);
+      } catch {
+        continue;
+      }
+
+      if (!stats.isDirectory()) {
+        continue;
+      }
+
+      if (segments.includes(candidate)) {
+        continue;
+      }
+
+      segments.unshift(candidate);
+    }
+
+    process.env.PATH = segments.join(path.delimiter);
+  }
+
+  private normalizeCommandCandidates(preferred: string, fallbacks: string[]): string[] {
+    const seen = new Set<string>();
+    const candidates: string[] = [];
+    for (const candidate of [preferred, ...fallbacks]) {
+      if (!candidate) {
+        continue;
+      }
+      const key = candidate.trim();
+      if (key.length === 0 || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      candidates.push(key);
+    }
+    return candidates;
+  }
+
+  private isExplicitPath(command: string): boolean {
+    return command.includes('/') || command.includes('\\');
+  }
+
+  private checkExplicitPath(commandPath: string): string | null {
+    try {
+      const stats = fs.statSync(commandPath);
+      return stats.isFile() ? commandPath : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private findInSystemPath(command: string): string | null {
+    const envPath = process.env.PATH || '';
+    const pathSegments = envPath.split(path.delimiter).filter((segment) => segment && segment.trim().length > 0);
+
+    const extensions =
+      process.platform === 'win32'
+        ? (process.env.PATHEXT || '')
+            .split(';')
+            .map((ext) => ext.trim())
+            .filter((ext) => ext.length > 0)
+        : [''];
+
+    for (const segment of pathSegments) {
+      for (const ext of extensions) {
+        const candidatePath = path.join(segment, `${command}${ext}`);
+        try {
+          const stats = fs.statSync(candidatePath);
+          if (stats.isFile()) {
+            return candidatePath;
+          }
+        } catch {
+          // Ignore inaccessible or missing files.
+        }
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- add fallback resolution for the Tesseract and pdftoppm binaries so Render installs are detected automatically
- log helpful warnings and surface the resolved command path when OCR executables are missing
- prepend Render's .apt bin directories to PATH and include additional fallback locations to reliably discover apt-installed binaries at runtime

## Testing
- npm --prefix soft-sme-backend run build

------
https://chatgpt.com/codex/tasks/task_e_68e4918d6b088324b9869a6b16ca1754