### PR TITLE
Fix Render build script for backend deployment

### DIFF
--- a/render-build.sh
+++ b/render-build.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cat <<'MSG'
-This project now deploys via the Dockerfile at the repository root.
-Please switch your Render service to the Docker runtime and clear any
-custom build or start commands so Render uses the Docker image instead
-of render-build.sh.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="${SCRIPT_DIR}/soft-sme-backend"
+BACKEND_SCRIPT="${BACKEND_DIR}/render-build.sh"
 
-See render.yaml for an example Docker-based configuration.
+if [[ -x "${BACKEND_SCRIPT}" ]]; then
+  echo "Delegating Render build to ${BACKEND_SCRIPT}" >&2
+  exec "${BACKEND_SCRIPT}"
+fi
+
+cat <<'MSG'
+render-build.sh is intended to be executed from the soft-sme-backend
+subdirectory. The expected build script now lives at
+soft-sme-backend/render-build.sh. Ensure your Render service's root directory
+is set to soft-sme-backend so the build command can find the script.
 MSG
 
 exit 1

--- a/soft-sme-backend/render-build.sh
+++ b/soft-sme-backend/render-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+function log() {
+  printf '\n[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+log "Starting Render build for soft-sme-backend"
+
+APT_FILE="${SCRIPT_DIR}/apt.txt"
+SKIP_APT_INSTALL="${SKIP_APT_INSTALL:-0}"
+
+if [[ -f "${APT_FILE}" ]]; then
+  if [[ "${SKIP_APT_INSTALL}" == "1" ]]; then
+    log "apt.txt detected but SKIP_APT_INSTALL=1, skipping package installation"
+  else
+    log "apt.txt detected. Installing required apt packages"
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    xargs -a "${APT_FILE}" -r apt-get install -y --no-install-recommends
+    rm -rf /var/lib/apt/lists/*
+  fi
+else
+  log "No apt.txt file detected. Skipping apt package installation"
+fi
+
+if [[ -f package-lock.json ]]; then
+  log "Installing npm dependencies with npm ci"
+  npm ci
+else
+  log "No package-lock.json found. Falling back to npm install"
+  npm install
+fi
+
+log "Building TypeScript sources"
+npm run build
+
+log "Render build script completed successfully"


### PR DESCRIPTION
## Summary
- add a backend-local render-build.sh that installs apt packages, installs npm dependencies, and runs the build
- update the root render-build.sh to delegate to the backend script for compatibility with existing build commands

## Testing
- `SKIP_APT_INSTALL=1 ./soft-sme-backend/render-build.sh` *(fails in this environment while building bcrypt from source because required binaries/headers cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a164d30c8324b0f7ef2ab9eefc9b