### PR TITLE
Handle read-only apt installs in Render build script

### DIFF
--- a/soft-sme-backend/render-build.sh
+++ b/soft-sme-backend/render-build.sh
@@ -13,15 +13,41 @@ log "Starting Render build for soft-sme-backend"
 APT_FILE="${SCRIPT_DIR}/apt.txt"
 SKIP_APT_INSTALL="${SKIP_APT_INSTALL:-0}"
 
+function can_use_apt() {
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "apt-get is not available in this environment"
+    return 1
+  fi
+
+  local apt_lists_dir="/var/lib/apt/lists"
+  if [[ ! -d "${apt_lists_dir}" ]]; then
+    if ! mkdir -p "${apt_lists_dir}" 2>/dev/null; then
+      log "Unable to create ${apt_lists_dir}; filesystem may be read-only"
+      return 1
+    fi
+  fi
+
+  local writability_probe="${apt_lists_dir}/.apt-writability-check"
+  if ! touch "${writability_probe}" 2>/dev/null; then
+    log "Cannot write to ${apt_lists_dir}; skipping apt package installation"
+    return 1
+  fi
+
+  rm -f "${writability_probe}" 2>/dev/null || true
+  return 0
+}
+
 if [[ -f "${APT_FILE}" ]]; then
   if [[ "${SKIP_APT_INSTALL}" == "1" ]]; then
     log "apt.txt detected but SKIP_APT_INSTALL=1, skipping package installation"
-  else
+  elif can_use_apt; then
     log "apt.txt detected. Installing required apt packages"
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     xargs -a "${APT_FILE}" -r apt-get install -y --no-install-recommends
     rm -rf /var/lib/apt/lists/*
+  else
+    log "apt prerequisites not met; skipping apt package installation"
   fi
 else
   log "No apt.txt file detected. Skipping apt package installation"


### PR DESCRIPTION
## Summary
- add an apt availability check to the backend Render build script
- skip apt installations when the filesystem is read-only or apt-get is unavailable while logging clear messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a4dab1a48324b209d28d2baceb17