### PR TITLE
Prevent navigation to restricted areas

### DIFF
--- a/soft-sme-frontend/src/components/Layout.tsx
+++ b/soft-sme-frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, Outlet } from 'react-router-dom';
+import { useNavigate, Outlet, useLocation } from 'react-router-dom';
 import {
   AppBar,
   Box,
@@ -55,6 +55,7 @@ const drawerWidth = 240;
 const Layout: React.FC = () => {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const { logout, user } = useAuth();
   const { isOpen, toggleChat, closeChat, unreadCount } = useChat();
   const { unreadConversationCount } = useMessaging();
@@ -98,6 +99,13 @@ const Layout: React.FC = () => {
     }),
     [unreadConversationCount]
   );
+
+  const resolveNavigationPath = (targetPath: string): string => {
+    if (targetPath === '/tasks' || targetPath === '/messaging') {
+      return '/';
+    }
+    return targetPath;
+  };
 
   const menuItems = useMemo<MenuEntry[]>(
     () => [
@@ -198,7 +206,10 @@ const Layout: React.FC = () => {
             <ListItem
               key={navItem.path || `${navItem.text}-${idx}`}
               onClick={() => {
-                navigate(navItem.path);
+                const destination = resolveNavigationPath(navItem.path);
+                if (location.pathname !== destination) {
+                  navigate(destination);
+                }
                 setMobileOpen(false);
               }}
               sx={{ cursor: 'pointer' }}

--- a/soft-sme-frontend/src/pages/LandingPage.tsx
+++ b/soft-sme-frontend/src/pages/LandingPage.tsx
@@ -195,7 +195,7 @@ const LandingPage: React.FC = () => {
           summary={taskSummary}
           loading={taskSummaryLoading}
           onRefresh={loadTaskSummary}
-          onViewTasks={() => navigate('/tasks')}
+          onViewTasks={() => navigate('/')}
         />
       </Box>
 


### PR DESCRIPTION
## Summary
- redirect sidebar clicks for Tasks and Messaging back to the landing page
- keep the Task summary widget on the landing page when its quick action is used

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4bfc344448324b7f331a2ec682d0b