### PR TITLE
Remove manual raw text AI review interface

### DIFF
--- a/soft-sme-backend/src/services/PurchaseOrderAiReviewService.ts
+++ b/soft-sme-backend/src/services/PurchaseOrderAiReviewService.ts
@@ -17,67 +17,6 @@ interface PurchaseOrderAiStructuredResponse {
 const DEFAULT_MODEL = process.env.AI_MODEL || 'gemini-2.5-flash';
 const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${DEFAULT_MODEL}:generateContent`;
 
-const RESPONSE_SCHEMA = {
-  type: 'object',
-  properties: {
-    normalized: {
-      type: 'object',
-      properties: {
-        vendorName: { type: ['string', 'null'] },
-        vendorAddress: { type: ['string', 'null'] },
-        billNumber: { type: ['string', 'null'] },
-        billDate: { type: ['string', 'null'] },
-        gstRate: { type: ['number', 'null'] },
-        currency: { type: ['string', 'null'] },
-        documentType: {
-          type: 'string',
-          enum: ['invoice', 'packing_slip', 'receipt', 'unknown'],
-        },
-        detectedKeywords: {
-          type: 'array',
-          items: { type: 'string' },
-        },
-        lineItems: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              rawLine: { type: 'string' },
-              partNumber: { type: ['string', 'null'] },
-              description: { type: 'string' },
-              quantity: { type: ['number', 'null'] },
-              unit: { type: ['string', 'null'] },
-              unitCost: { type: ['number', 'null'] },
-              totalCost: { type: ['number', 'null'] },
-            },
-            required: ['rawLine', 'description'],
-          },
-        },
-      },
-      required: [
-        'vendorName',
-        'vendorAddress',
-        'billNumber',
-        'billDate',
-        'gstRate',
-        'currency',
-        'documentType',
-        'detectedKeywords',
-        'lineItems',
-      ],
-    },
-    warnings: {
-      type: 'array',
-      items: { type: 'string' },
-    },
-    notes: {
-      type: 'array',
-      items: { type: 'string' },
-    },
-  },
-  required: ['normalized', 'warnings', 'notes'],
-} as const;
-
 const SYSTEM_INSTRUCTIONS = `You are helping an inventory specialist capture purchase order details.
 Extract structured data from raw invoice or packing slip text.
 Return a JSON object that exactly matches the following schema:
@@ -144,7 +83,6 @@ export class PurchaseOrderAiReviewService {
         maxOutputTokens: 2048,
         responseMimeType: 'application/json',
       },
-      responseSchema: RESPONSE_SCHEMA,
       safetySettings: [
         {
           category: 'HARM_CATEGORY_HARASSMENT',


### PR DESCRIPTION
## Summary
- remove the manual raw text analysis form from the open purchase order page
- drop the raw text preview toggle so only structured OCR results are shown

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5913bf3648324b1b7b1c681ae7229